### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+
+- package-ecosystem: "pip"
+  directory: "signer/"
+  schedule:
+    interval: "daily"
+    time: "10:25"
+
+- package-ecosystem: "pip"
+  directory: "repo/"
+  schedule:
+    interval: "daily"
+    time: "10:25"
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+    time: "10:25"
+
+- package-ecosystem: "github-actions"
+  directory: "actions/offline-version-bump/"
+  schedule:
+    interval: "daily"
+    time: "10:25"
+
+- package-ecosystem: "github-actions"
+  directory: "actions/online-version-bump/"
+  schedule:
+    interval: "daily"
+    time: "10:25"
+
+- package-ecosystem: "github-actions"
+  directory: "actions/signing-event/"
+  schedule:
+    interval: "daily"
+    time: "10:25"
+
+- package-ecosystem: "github-actions"
+  directory: "actions/snapshot/"
+  schedule:
+    interval: "daily"
+    time: "10:25"


### PR DESCRIPTION
Handle
* GH workflows used in this projects CI
* GH actions published for others to use
* both pyproject.toml files

This will create ~15 PRs as soon as merged (because all dependent actions in our actions will be updated and the different actions will get separate PRs)

Fixes #7