### PR TITLE
workfows: Add release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+concurrency: release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions: {}
+
+jobs:
+  build-signer:
+    name: Build tuf-on-ci signer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+
+      - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
+        with:
+          python-version: '3.11'
+
+      - name: Install build dependencies
+        run: python3 -m pip install build
+
+      - name: Build binary wheel and source tarball
+        run: python3 -m build --sdist --wheel --outdir dist/ signer/
+
+      - name: Store build artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        with:
+          name: signer-artifacts
+          path: dist
+
+  release-pypi:
+    name: Release Signer on PyPI
+    runs-on: ubuntu-latest
+    needs: build-signer
+    environment: release
+    permissions:
+      id-token: write # to authenticate as Trusted Publisher to pypi.org
+    steps:
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: signer-artifacts
+          path: dist
+
+      - name: Publish binary wheel and source tarball on PyPI
+        if: github.repository == 'theupdateframework/tuf-on-ci'
+        uses: pypa/gh-action-pypi-publish@f8c70e705ffc13c3b4d1221169b84f12a75d6ca8
+
+  release-gh:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: release-pypi
+    permissions:
+      contents: write # to modify GitHub releases
+    steps:
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: signer-artifacts
+          path: dist
+
+      - name: Make a GitHub release
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        with:
+          script: |
+            fs = require('fs')
+            res = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: '${{ github.ref_name }}',
+              tag_name: '${{ github.ref }}',
+              body: 'See [CHANGELOG.md](https://github.com/' +
+                     context.repo.owner + '/' + context.repo.repo +
+                    '/blob/${{ github.ref_name }}/docs/CHANGELOG.md) for details.'
+            })
+            fs.readdirSync('dist/').forEach(file => {
+              github.rest.repos.uploadReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: res.data.id,
+                name: file,
+                data: fs.readFileSync('dist/' + file),
+              });
+            });

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,12 @@
+## Release process
+
+1. Ensure `docs/CHANGELOG.md` contains a summary of notable changes since the
+   prior release. Check that all required changes to workflows that
+   call our actions are clearly documented.
+2. Update version number in `signer/pyproject.toml` and `repo/pyproject.toml`
+3. Create a PR with the updated CHANGELOG and version bumps.
+4. Once the PR is merged, create a signed tag for the version number on the merge commit
+  `git tag --sign vA.B.C -m "vA.B.C"`
+6. Push the tag to GitHub `git push origin vA.B.C`. This triggers release workflow
+7. [Review deployment](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments)
+on GitHub. On approval both the PyPI signer release and the GitHub release will be deployed


### PR DESCRIPTION
Three steps:
* build signer
* Make signer release to pypi
* Make overall release on GitHub

This means at the moment signer and repository releases are tied to each other.

The release environment has been created: deployment requires approval from one of [jku, kommendorkapten, lukpueh].

The PyPI Trusted Publishing setup is "pending": it should become an actual setup on first release.

I have tested this (except for the pypi publishing part: that can only succeed on the upstream project)