### PR TITLE
Update Changelog after release

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,11 @@ Features include:
 * Polished signing user experience
 * No custom code required
 
-The signer is available from PyPI: `pip install tuf-on-ci-sign`.
-See [README.md](../README.md) for repository setup instructions.
 
+The signer is *not* available from PyPI in this release but will be in future releases.
+See [README.md](../README.md) for repository and signer setup instructions.
+
+### Upgrading an existing repository installation
+
+* Start pinning tuf-on-ci actions in your workflows (see example in https://github.com/theupdateframework/tuf-on-ci-template/pull/3)
+* Use Dependabot in your GitHub project to get automatic update PRs in the future


### PR DESCRIPTION
* Signer release is not happening yet
* Add info on upgrading an existing release

First item was only realized after release, second should have been included in the release already but was forgotten.