### PR TITLE
signer: Add import tool

### DIFF
--- a/repo/tuf_on_ci/_repository.py
+++ b/repo/tuf_on_ci/_repository.py
@@ -134,7 +134,13 @@ class CIRepository(Repository):
         keys = []
         for keyid in r.keyids:
             try:
-                keys.append(delegator.get_key(keyid))
+                key = delegator.get_key(keyid)
+                if known_good and "x-tuf-on-ci-keyowner" not in key.unrecognized_fields:
+                    # this is allowed for repo import case: we cannot identify known
+                    # good keys and have to trust that delegations have not changed
+                    continue
+
+                keys.append(key)
             except ValueError:
                 pass
         return keys

--- a/repo/tuf_on_ci/_repository.py
+++ b/repo/tuf_on_ci/_repository.py
@@ -539,3 +539,14 @@ class CIRepository(Repository):
             return True
 
         return False
+
+    def is_verified(self, rolename: str) -> bool:
+        if rolename in ["root", "timestamp", "snapshot", "targets"]:
+            delegator = self.open("root")
+        else:
+            delegator = self.open("targets")
+        try:
+            delegator.verify_delegate(rolename, self.open(rolename))
+            return True
+        except UnsignedMetadataError:
+            return False

--- a/repo/tuf_on_ci/snapshot.py
+++ b/repo/tuf_on_ci/snapshot.py
@@ -43,11 +43,13 @@ def snapshot(
     logging.basicConfig(level=logging.WARNING - verbose * 10)
 
     repo = CIRepository("metadata")
-    snapshot_updated, _ = repo.do_snapshot()
+    verified = repo.is_verified("snapshot")
+    snapshot_updated, _ = repo.do_snapshot(not verified)
     if not snapshot_updated:
         click.echo("No snapshot needed")
     else:
-        repo.do_timestamp()
+        verified = repo.is_verified("timestamp")
+        repo.do_timestamp(not verified)
 
         msg = "Snapshot & timestamp"
         _git(["add", "metadata/timestamp.json", "metadata/snapshot.json"])

--- a/signer/pyproject.toml
+++ b/signer/pyproject.toml
@@ -21,6 +21,7 @@ requires-python = ">=3.10"
 
 [project.scripts]
 tuf-on-ci-delegate = "tuf_on_ci_sign:delegate"
+tuf-on-ci-import-repo = "tuf_on_ci_sign:import_repo"
 tuf-on-ci-sign = "tuf_on_ci_sign:sign"
 
 [[tool.mypy.overrides]]

--- a/signer/tuf_on_ci_sign/__init__.py
+++ b/signer/tuf_on_ci_sign/__init__.py
@@ -1,4 +1,5 @@
 from tuf_on_ci_sign.delegate import delegate
+from tuf_on_ci_sign.import_repo import import_repo
 from tuf_on_ci_sign.sign import sign
 
-__all__ = ["delegate", "sign"]
+__all__ = ["delegate", "import_repo", "sign"]

--- a/signer/tuf_on_ci_sign/import_repo.py
+++ b/signer/tuf_on_ci_sign/import_repo.py
@@ -150,8 +150,6 @@ def import_repo(verbose: int, push: bool, event_name: str, import_file: str | No
 
             role_data = import_data[rolename]
             if rolename == "root":
-                # BUG: this does not work because edit_root tries to sing with
-                # old keys as well: they won't have the correct custom metadata
                 with repo.edit_root() as root:
                     ok = _update_expiry(root, role_data) and ok
                     ok = _update_signing(root, role_data) and ok

--- a/signer/tuf_on_ci_sign/import_repo.py
+++ b/signer/tuf_on_ci_sign/import_repo.py
@@ -1,0 +1,210 @@
+# Copyright 2023 Google LLC
+
+"""tuf-on-ci-import: A command line import tool for TUF-on-CI signing events"""
+
+import json
+import logging
+import os
+from glob import glob
+
+import click
+from tuf.api.metadata import Key, Role, Signed
+
+from tuf_on_ci_sign._common import (
+    bold,
+    git_echo,
+    git_expect,
+    signing_event,
+)
+from tuf_on_ci_sign._signer_repository import AbortEdit
+from tuf_on_ci_sign._user import User
+
+logger = logging.getLogger(__name__)
+
+EXPIRY_KEY = "x-tuf-on-ci-expiry-period"
+SIGNING_KEY = "x-tuf-on-ci-signing-period"
+ONLINE_URI_KEY = "x-tuf-on-ci-online-uri"
+KEYOWNER_KEY = "x-tuf-on-ci-keyowner"
+
+
+def _update_expiry(obj: Signed | Role, import_data: dict[str, int]):
+    if EXPIRY_KEY in import_data and import_data[EXPIRY_KEY] != -1:
+        expiry = import_data[EXPIRY_KEY]
+    elif EXPIRY_KEY in obj.unrecognized_fields:
+        expiry = obj.unrecognized_fields[EXPIRY_KEY]
+    elif "x-playground-expiry-period" in obj.unrecognized_fields:
+        expiry = obj.unrecognized_fields["x-playground-expiry-period"]
+    else:
+        # let user know this is needed
+        import_data[EXPIRY_KEY] = -1
+        return False
+
+    # set the value
+    obj.unrecognized_fields[EXPIRY_KEY] = expiry
+    # unset legacy playground value
+    obj.unrecognized_fields.pop("x-playground-expiry-period", None)
+
+    return True
+
+
+def _update_signing(obj: Signed | Role, import_data: dict[str, int]):
+    if SIGNING_KEY in import_data and import_data[SIGNING_KEY] != -1:
+        signing = import_data[SIGNING_KEY]
+    elif SIGNING_KEY in obj.unrecognized_fields:
+        signing = obj.unrecognized_fields[SIGNING_KEY]
+    elif "x-playground-signing-period" in obj.unrecognized_fields:
+        signing = obj.unrecognized_fields["x-playground-signing-period"]
+    elif "x-playground-expiry-period" in obj.unrecognized_fields:
+        # signing-period was not required at some point
+        signing = obj.unrecognized_fields["x-playground-expiry-period"] // 2
+    else:
+        # let user know this is needed
+        import_data[SIGNING_KEY] = -1
+        return False
+
+    # set the value
+    obj.unrecognized_fields[SIGNING_KEY] = signing
+    # unset legacy playground value
+    obj.unrecognized_fields.pop("x-playground-signing-period", None)
+
+    return True
+
+
+def _update_keys(keys: dict[str, Key], import_data: dict[str, str]):
+    success = True
+    undefined = "UNDEFINED ONLINE_URI OR KEYOWNER"
+    for key in keys.values():
+        if key.keyid in import_data and import_data[key.keyid] != undefined:
+            value = import_data[key.keyid]
+        elif ONLINE_URI_KEY in key.unrecognized_fields:
+            value = key.unrecognized_fields[ONLINE_URI_KEY]
+        elif KEYOWNER_KEY in key.unrecognized_fields:
+            value = key.unrecognized_fields[KEYOWNER_KEY]
+        elif "x-playground-online-uri" in key.unrecognized_fields:
+            value = key.unrecognized_fields["x-playground-online-uri"]
+        elif "x-playground-keyowner" in key.unrecognized_fields:
+            value = key.unrecognized_fields["x-playground-keyowner"]
+        else:
+            # let user know this is needed
+            import_data[key.keyid] = undefined
+            success = False
+            continue
+
+        # set the value, unset legacy value
+        if value.startswith("@"):
+            key.unrecognized_fields[KEYOWNER_KEY] = value
+            key.unrecognized_fields.pop("x-playground-keyowner", None)
+        else:
+            key.unrecognized_fields[ONLINE_URI_KEY] = value
+            key.unrecognized_fields.pop("x-playground-online-uri", None)
+
+    return success
+
+
+@click.command()  # type: ignore[arg-type]
+@click.option("-v", "--verbose", count=True, default=0)
+@click.option("--push/--no-push", default=True)
+@click.argument("event-name", metavar="signing-event")
+@click.argument("import-file", required=False)
+def import_repo(verbose: int, push: bool, event_name: str, import_file: str | None):
+    """Repository import tool for TUF-on-CI signing events.
+
+    Works on both unmanaged repositories and legacy playground-repository managed
+    repositories.
+
+    \b
+    tuf-on-ci-import-repo <EVENT>
+        Creates a signing event with all of the import changes or, if there are missing
+        custom metadata fields, prints out import file contents that can be filled.
+
+    \b
+    tuf-on-ci-import-repo <EVENT> <IMPORTFILE>
+        Creates a signing event with all of the import changes using the import file
+        to fill in missing custom metadata.
+    """
+    logging.basicConfig(level=logging.WARNING - verbose * 10)
+
+    toplevel = git_expect(["rev-parse", "--show-toplevel"])
+    settings_path = os.path.join(toplevel, ".tuf-on-ci-sign.ini")
+    user_config = User(settings_path)
+
+    if import_file:
+        with open(import_file) as f:
+            import_data = json.load(f)
+    else:
+        import_data = {}
+
+    with signing_event(event_name, user_config) as repo:
+        ok = True
+        # handle root and all target files, in order of delegations
+        roles = ["root", "targets"]
+        for filename in glob("*.json", root_dir=f"{toplevel}/metadata"):
+            rolename = filename[: -len(".json")]
+            if rolename in ["root", "timestamp", "snapshot", "targets"]:
+                continue
+            roles.append(rolename)
+
+        for rolename in roles:
+            if rolename not in import_data:
+                import_data[rolename] = {}
+
+            role_data = import_data[rolename]
+            if rolename == "root":
+                # BUG: this does not work because edit_root tries to sing with
+                # old keys as well: they won't have the correct custom metadata
+                with repo.edit_root() as root:
+                    ok = _update_expiry(root, role_data) and ok
+                    ok = _update_signing(root, role_data) and ok
+
+                    for online_rolename in ["timestamp", "snapshot"]:
+                        role = root.get_delegated_role(online_rolename)
+                        ok = _update_expiry(role, role_data) and ok
+                        ok = _update_signing(role, role_data) and ok
+
+                    ok = _update_keys(root.keys, role_data) and ok
+                    if not ok:
+                        raise AbortEdit("Missing values")
+            else:
+                with repo.edit_targets(rolename) as targets:
+                    ok = _update_expiry(targets, role_data) and ok
+                    ok = _update_signing(targets, role_data) and ok
+
+                    if targets.delegations:
+                        ok = _update_keys(targets.delegations.keys, role_data) and ok
+                    if not ok:
+                        raise AbortEdit("Missing values")
+
+        if not ok:
+            print("Error: Undefined values found. please save this in a file,")
+            print("fill in the values and use the file as import-file argument:\n")
+            print(json.dumps(import_data, indent=2))
+        else:
+            git_expect(["add", "metadata"])
+            git_expect(["commit", "-m", f"Repo import by {user_config.name}"])
+
+            if repo.unsigned:
+                click.echo(f"Your signature is required for role(s) {repo.unsigned}.")
+
+                for rolename in repo.unsigned:
+                    click.echo(repo.status(rolename))
+                    repo.sign(rolename)
+
+                git_expect(["add", "metadata/"])
+                git_expect(["commit", "-m", f"Signed by {user_config.name}"])
+
+            if push:
+                branch = f"{user_config.push_remote}/{event_name}"
+                msg = f"Press enter to push signature(s) to {branch}"
+                click.prompt(bold(msg), default=True, show_default=False)
+                git_echo(
+                    [
+                        "push",
+                        "--progress",
+                        user_config.push_remote,
+                        f"HEAD:refs/heads/{event_name}",
+                    ]
+                )
+            else:
+                # TODO: maybe deal with existing branch?
+                click.echo(f"Creating local branch {event_name}")
+                git_expect(["branch", event_name])


### PR DESCRIPTION
@kommendorkapten not sure if this is too late for you but... `tuf-on-ci-import-repo <EVENT> [<IMPORTDATA>]` will import
* legacy playground repos
* generic tuf repositories (when given additional import configuration file which the tool can pre-generate)

This is a draft since 
* it's quite untested
* I'm unsure if adding something like this into the core code base is smart: it's just 200 lines but it's unlikely to get tested well as it will be only ran a few times
* needs documentation that explains the steps of importing
  * create a repository with the original metadata in the expected place
  * add workflows from tuf-on-ci-template
  * setup signer tool locally
  * handle unsupported keys somehow
  * run tuf-on-ci-import-repo to start a signing event

still, I think it's surprisingly self contained: I only needed to add one hack into the SignerRepository: otherwise it's a separate tool that cannot break anything else
