### PR TITLE
actions: Use repos API instead of search API

### DIFF
--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -72,12 +72,14 @@ runs:
 
           issue = 0
           const repo = context.repo.owner + "/" + context.repo.repo
-          const issues = await github.rest.search.issuesAndPullRequests({
-            q: "label:" + process.env.GITHUB_REF_NAME + "+state:open+type:issue+repo:" + repo,
+          const issues = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: [process.env.GITHUB_REF_NAME],
           })
-          if (issues.data.total_count > 1) {
+          if (issues.data.length > 1) {
             core.setFailed("Found more than one issue with same label")
-          } else if (issues.data.total_count == 0) {
+          } else if (issues.data.length == 0) {
             const response = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -88,7 +90,7 @@ runs:
             issue = response.data.number
             console.log("Created issue #" + issue)
           } else {
-            issue = issues.data.items[0].number
+            issue = issues.data[0].number
             console.log("Found existing issue #" + issue)
           }
 


### PR DESCRIPTION
(PR moved from playground)

Former is arguably the correct choice (search API is global, not project specific) and we have seen at least one case where the search API did not have the content that was already available in repos API and this lasted for a few hours.

Differences:
* new API lists only open issues by default
* new API does not allow filtering by issue type (so we theoretically could find PRs too): I don't think this is an issue as the PRs do not get a label automatically and we are searching based on label