### PR TITLE
signer: Refactor user configuration

### DIFF
--- a/signer/test/test_user.py
+++ b/signer/test/test_user.py
@@ -1,0 +1,112 @@
+import os
+import unittest
+from tempfile import TemporaryDirectory
+
+import click
+from securesystemslib.signer import HSMSigner, SSlibKey
+
+from tuf_on_ci_sign._user import User
+
+# Long lines are ok here
+# ruff: noqa: E501
+
+REQUIRED = """
+[settings]
+pykcs11lib = /usr/lib/x86_64-linux-gnu/libykcs11.so
+user-name = @signer
+push-remote = origin
+pull-remote = myremote
+"""
+
+MISSING_NAME = """
+[settings]
+pykcs11lib = /usr/lib/x86_64-linux-gnu/libykcs11.so
+push-remote = origin
+pull-remote = myremote
+"""
+
+REQUIRED_AND_SIGNING_KEYS = """
+[settings]
+pykcs11lib = /usr/lib/x86_64-linux-gnu/libykcs11.so
+user-name = @signer
+push-remote = origin
+pull-remote = myremote
+
+[signing-keys]
+762cb22caca65de5e9b7b6baecb84ca989d337280ce6914b6440aea95769ad93 = hsm:2?label=YubiKey+PIV+%2315835999
+01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b = file:keys/mykey?encrypted=false
+"""
+
+HSM_KEY = SSlibKey(
+    "762cb22caca65de5e9b7b6baecb84ca989d337280ce6914b6440aea95769ad93",
+    "ecdsa",
+    "ecdsa-sha2-nistp256",
+    {
+        "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEohqIdE+yTl4OxpX8ZxNUPrg3SL9H\nBDnhZuceKkxy2oMhUOxhWweZeG3bfM1T4ZLnJimC6CAYVU5+F5jZCoftRw==\n-----END PUBLIC KEY-----\n"
+    },
+)
+
+NONCONFIGURED_KEY = SSlibKey(
+    "64eeece964e09c058ef8f9805daca546b01ba4719c80b6fe911b091a7c05124b",
+    "ecdsa",
+    "ecdsa-sha2-nistp256",
+    {
+        "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu+ebm3VUg6U2b0IIeR6NFZU7uxkL\nR1sVLxV8SEW7G+AMXMasEQf5daxfwVMP1kuEkhGs3mBYLkYXlWDh9BNSxg==\n-----END PUBLIC KEY-----\n"
+    },
+)
+
+
+class TestUser(unittest.TestCase):
+    """Test configuration management and signer caching"""
+
+    def test_required(self):
+        with TemporaryDirectory() as tempdir:
+            inifile = os.path.join(tempdir, ".tuf-on-ci-sign.ini")
+            with open(inifile, "w") as f:
+                f.write(REQUIRED)
+
+            user = User(inifile)
+            self.assertEqual(user.name, "@signer")
+            self.assertEqual(user.pykcs11lib, "/usr/lib/x86_64-linux-gnu/libykcs11.so")
+            self.assertEqual(user.push_remote, "origin")
+            self.assertEqual(user.pull_remote, "myremote")
+
+            with open(inifile, "w") as f:
+                f.write(MISSING_NAME)
+            with self.assertRaises(click.ClickException):
+                user = User(inifile)
+
+    def test_signing_keys(self):
+        with TemporaryDirectory() as tempdir:
+            inifile = os.path.join(tempdir, ".tuf-on-ci-sign.ini")
+            with open(inifile, "w") as f:
+                f.write(REQUIRED_AND_SIGNING_KEYS)
+
+            user = User(inifile)
+            # We should get a signer for the configured HSM
+            hsm_signer = user.get_signer(HSM_KEY)
+            self.assertIsInstance(hsm_signer, HSMSigner)
+            self.assertEqual(
+                hsm_signer.token_filter, {"label": "YubiKey PIV #15835999"}
+            )
+            self.assertEqual(
+                hsm_signer.public_key.keyid,
+                "762cb22caca65de5e9b7b6baecb84ca989d337280ce6914b6440aea95769ad93",
+            )
+
+            # If the signing key is not configured, we expect a generic HSM signer
+            other_signer = user.get_signer(NONCONFIGURED_KEY)
+            self.assertIsInstance(other_signer, HSMSigner)
+            self.assertEqual(other_signer.token_filter, {})
+            self.assertEqual(
+                other_signer.public_key.keyid,
+                "64eeece964e09c058ef8f9805daca546b01ba4719c80b6fe911b091a7c05124b",
+            )
+
+            # another lookup should return same instance
+            second_hsm_signer = user.get_signer(HSM_KEY)
+            self.assertIs(hsm_signer, second_hsm_signer)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/signer/tuf_on_ci_sign/_user.py
+++ b/signer/tuf_on_ci_sign/_user.py
@@ -1,0 +1,75 @@
+import sys
+from configparser import ConfigParser
+
+import click
+from securesystemslib.signer import Key, Signer
+
+
+def bold(text: str) -> str:
+    return click.style(text, bold=True)
+
+
+class User:
+    """Class that manages user configuration and manages the users signer cache"""
+
+    def __init__(self, path: str):
+        self._config_path = path
+
+        self._config = ConfigParser(interpolation=None)
+        self._config.read(path)
+
+        # TODO: create config if missing, ask/confirm values from user
+        if not self._config:
+            raise click.ClickException(f"Settings file {path} not found")
+        try:
+            self.name = self._config["settings"]["user-name"]
+            self.pykcs11lib = self._config["settings"]["pykcs11lib"]
+            self.push_remote = self._config["settings"]["push-remote"]
+            self.pull_remote = self._config["settings"]["pull-remote"]
+        except KeyError as e:
+            raise click.ClickException(f"Failed to find required setting {e} in {path}")
+
+        # signing key config is not required
+        if "signing-keys" in self._config:
+            self._signing_key_uris = dict(self._config.items("signing-keys"))
+        else:
+            self._signing_key_uris = {}
+
+        # signer cache gets populated as they are used the first time
+        self._signers: dict[str, Signer] = {}
+
+    def get_signer(self, key: Key) -> Signer:
+        """Returns a Signer for the given public key
+
+        The signer sources are (in order):
+        * any configured signer from 'signing-keys' config section
+        * for sigstore type keys, a Signer is automatically created
+        * for any remaining keys, HSM is assumed and a signer is created
+        """
+
+        def get_secret(secret: str) -> str:
+            msg = f"Enter {secret} to sign"
+
+            # special case for tests -- prompt() will lockup trying to hide STDIN:
+            if not sys.stdin.isatty():
+                return sys.stdin.readline().rstrip()
+
+            return click.prompt(bold(msg), hide_input=True)
+
+        if key.keyid in self._signers:
+            # signer is already cached
+            pass
+        elif key.keyid in self._signing_key_uris:
+            # signer is not cached yet, but config exists
+            uri = self._signing_key_uris[key.keyid]
+            self._signers[key.keyid] = Signer.from_priv_key_uri(uri, key, get_secret)
+        elif key.keytype == "sigstore-oidc":
+            # signer is not cached, no configuration was found, type is sigstore
+            self._signers[key.keyid] = Signer.from_priv_key_uri(
+                "sigstore:?ambient=false", key, get_secret
+            )
+        else:
+            # signer is not cached, no configuration was found: assume Yubikey
+            self._signers[key.keyid] = Signer.from_priv_key_uri("hsm:", key, get_secret)
+
+        return self._signers[key.keyid]

--- a/signer/tuf_on_ci_sign/delegate.py
+++ b/signer/tuf_on_ci_sign/delegate.py
@@ -248,7 +248,7 @@ def _collect_string(prompt: str) -> str:
             return data
 
 
-def _init_repository(repo: SignerRepository, user_config: User) -> bool:
+def _init_repository(repo: SignerRepository) -> bool:
     click.echo("Creating a new TUF-on-CI repository")
 
     root_config = _get_offline_input(
@@ -257,11 +257,11 @@ def _init_repository(repo: SignerRepository, user_config: User) -> bool:
     targets_config = _get_offline_input("targets", deepcopy(root_config))
 
     # As default we offer sigstore online key(s)
-    keys = _sigstore_import(user_config.pull_remote)
+    keys = _sigstore_import(repo.user.pull_remote)
     default_config = OnlineConfig(
         keys, 2, 1, root_config.expiry_period, root_config.signing_period
     )
-    online_config = _get_online_input(default_config, user_config)
+    online_config = _get_online_input(default_config, repo.user)
 
     key = None
     if (
@@ -325,7 +325,7 @@ def delegate(verbose: int, push: bool, event_name: str, role: str | None):
 
     with signing_event(event_name, user_config) as repo:
         if repo.state == SignerState.UNINITIALIZED:
-            changed = _init_repository(repo, user_config)
+            changed = _init_repository(repo)
         else:
             if role is None:
                 role = click.prompt(bold("Enter name of role to modify"))

--- a/signer/tuf_on_ci_sign/sign.py
+++ b/signer/tuf_on_ci_sign/sign.py
@@ -8,7 +8,6 @@ import os
 import click
 
 from tuf_on_ci_sign._common import (
-    SignerConfig,
     bold,
     get_signing_key_input,
     git_echo,
@@ -16,6 +15,7 @@ from tuf_on_ci_sign._common import (
     signing_event,
 )
 from tuf_on_ci_sign._signer_repository import SignerState
+from tuf_on_ci_sign._user import User
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ def sign(verbose: int, push: bool, event_name: str):
 
     toplevel = git_expect(["rev-parse", "--show-toplevel"])
     settings_path = os.path.join(toplevel, ".tuf-on-ci-sign.ini")
-    user_config = SignerConfig(settings_path)
+    user_config = User(settings_path)
 
     with signing_event(event_name, user_config) as repo:
         if repo.state == SignerState.UNINITIALIZED:
@@ -67,7 +67,7 @@ def sign(verbose: int, push: bool, event_name: str):
 
         if changed:
             git_expect(["add", "metadata"])
-            git_expect(["commit", "-m", f"Signed by {user_config.user_name}"])
+            git_expect(["commit", "-m", f"Signed by {user_config.name}"])
             if push:
                 branch = f"{user_config.push_remote}/{event_name}"
                 msg = f"Press enter to push signature(s) to {branch}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = lint-signer, lint-repo, test-repo, test-e2e
+env_list = lint-signer, lint-repo, test-repo, test-signer, test-e2e
 
 [testenv:lint-signer]
 description = Signer Linting
@@ -38,6 +38,16 @@ deps =
     -e repo/
 
 changedir = repo
+commands =
+    python -m unittest
+
+[testenv:test-signer]
+description = Signer unit tests
+labels = test
+deps =
+    -e signer/
+
+changedir = signer
 commands =
     python -m unittest
 


### PR DESCRIPTION
## Goals

* better code structure
* ability to configure signing systems in `.tuf-on-ci-sign.ini`

## Contents

Refactoring:
* Separate a _user module with a User class
* New class manages the users signers and configuration
* Design would allow User class to write the config (it does not currently)

New feature:
* privkeyuris can now be included in the configuration. These uris will then be used when signing. Example:

```
    [signing-keys]
    762cb22caca65de5e9b7b6baecb84ca989d337280ce6914b6440aea95769ad93 = hsm:2?label=YubiKey+PIV+%2315835999
```
The obvious next steps would be to automatically write the privkeyuris to the config when user becomes a signer. Technically this is possible to add already but I'm trying to keep the PR limited...