### PR TITLE
Fix small typo in the signer create-config-file script

### DIFF
--- a/signer/create-config-file.sh
+++ b/signer/create-config-file.sh
@@ -13,7 +13,7 @@ read GITHUB_HANDLE
 
 case ${OS} in
     Darwin)
-        if [ -f /opt/homebrew/lib/libykcs11.dyliba ]; then
+        if [ -f /opt/homebrew/lib/libykcs11.dylib ]; then
             YKSLIB=/opt/homebrew/lib/libykcs11.dylib
         elif [ -f /usr/local/lib/libykcs11.dylib ]; then
             YKSLIB=/usr/local/lib/libykcs11.dylib


### PR DESCRIPTION
This fixes a small typo found in `signer/create-config-file.sh` when the script checks the homebrew directory for `libykcs11.dylib`.