### PR TITLE
build(deps): bump actions/checkout from 3.5.3 to 3.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build tuf-on-ci signer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:

--- a/actions/offline-version-bump/action.yml
+++ b/actions/offline-version-bump/action.yml
@@ -4,7 +4,7 @@ description: 'Create signing events for offline signed metadata that is about to
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         fetch-depth: 0
 

--- a/actions/online-version-bump/action.yml
+++ b/actions/online-version-bump/action.yml
@@ -25,7 +25,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         path: repository
 

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -3,7 +3,7 @@ description: 'TUF-on-CI Signing event management'
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         fetch-depth: 0
 

--- a/actions/snapshot/action.yml
+++ b/actions/snapshot/action.yml
@@ -26,7 +26,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         path: repository
 


### PR DESCRIPTION
Minor changes only:
https://github.com/actions/checkout/blob/main/CHANGELOG.md

Add version number as a comment, dependabot should now update it.