### PR TITLE
Update dependencies (securesystemslib, sigstore)

### DIFF
--- a/repo/pyproject.toml
+++ b/repo/pyproject.toml
@@ -12,10 +12,9 @@ version = "0.0.1"
 description = "TUF-on-CI repository tools, intended to be executed on a CI system"
 readme = "README.md"
 dependencies = [
-  "sigstore @ git+https://github.com/sigstore/sigstore-python@7d4af6c5f6732ef12e5bb455962321ebe5cce137",
-  "securesystemslib[azurekms, gcpkms, sigstore, pynacl] @ git+https://github.com/secure-systems-lab/securesystemslib@bf63e1b0a58e35c3d5087d5ddd53e43d25e7250a",
-  "tuf ~= 3.0.0",
-  "click ~= 8.1.0",
+  "securesystemslib[azurekms, gcpkms, sigstore, pynacl] ~= 0.30",
+  "tuf ~= 3.0",
+  "click ~= 8.1",
 ]
 requires-python = ">=3.10"
 

--- a/signer/pyproject.toml
+++ b/signer/pyproject.toml
@@ -12,10 +12,9 @@ version = "0.0.1"
 description = "Signing tools for TUF-on-CI"
 readme = "README.md"
 dependencies = [
-  "sigstore @ git+https://github.com/sigstore/sigstore-python@7d4af6c5f6732ef12e5bb455962321ebe5cce137",
-  "securesystemslib[gcpkms,hsm,sigstore] @ git+https://github.com/secure-systems-lab/securesystemslib@bf63e1b0a58e35c3d5087d5ddd53e43d25e7250a",
-  "tuf ~= 3.0.0",
-  "click ~= 8.1.0",
+  "securesystemslib[gcpkms,hsm,sigstore] ~= 0.30",
+  "tuf ~= 3.0",
+  "click ~= 8.1",
 ]
 requires-python = ">=3.10"
 

--- a/signer/tuf_on_ci_sign/_common.py
+++ b/signer/tuf_on_ci_sign/_common.py
@@ -60,25 +60,8 @@ def get_signing_key_input() -> Key:
     )
 
     if choice == 1:
-        identity = click.prompt(bold("Please enter your email address"))
-        click.echo(" 1. GitHub")
-        click.echo(" 2. Google")
-        click.echo(" 3. Microsoft")
-        issuer_id = click.prompt(
-            bold("Please choose the identity issuer"),
-            type=click.IntRange(1, 3),
-            default=1,
-        )
-        if issuer_id == 1:
-            issuer = "https://github.com/login/oauth"
-        elif issuer_id == 2:
-            issuer = "https://accounts.google.com"
-        else:
-            issuer = "https://login.microsoftonline.com"
-        try:
-            _, key = SigstoreSigner.import_(identity, issuer, ambient=False)
-        except Exception as e:
-            raise click.ClickException(f"Failed to create Sigstore key: {e}")
+        click.echo(bold("Please authenticate with your Sigstore signing identity"))
+        _, key = SigstoreSigner.import_via_auth()
     else:
         click.prompt(
             bold("Please insert your Yubikey and press enter"),

--- a/signer/tuf_on_ci_sign/_signer_repository.py
+++ b/signer/tuf_on_ci_sign/_signer_repository.py
@@ -496,7 +496,7 @@ class SignerRepository(Repository):
                 role = DelegatedRole(rolename, [], 1, True, [f"{rolename}/*"])
                 if not delegator.delegations:
                     delegator.delegations = Delegations({}, {})
-                assert delegator.delegations.roles
+                assert delegator.delegations.roles is not None
                 delegator.delegations.roles[rolename] = role
                 changed = True
 

--- a/tests/expected/delegated/metadata/1.delegated.json
+++ b/tests/expected/delegated/metadata/1.delegated.json
@@ -1,0 +1,17 @@
+{
+ "signatures": [
+  {
+   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "targets",
+  "expires": "2022-02-03T01:02:03Z",
+  "spec_version": "1.0.31",
+  "targets": {},
+  "version": 1,
+  "x-tuf-on-ci-expiry-period": 365,
+  "x-tuf-on-ci-signing-period": 60
+ }
+}

--- a/tests/expected/delegated/metadata/1.root.json
+++ b/tests/expected/delegated/metadata/1.root.json
@@ -1,0 +1,65 @@
+{
+ "signatures": [
+  {
+   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": true,
+  "expires": "2022-02-03T01:02:03Z",
+  "keys": {
+   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp384",
+    "x-tuf-on-ci-keyowner": "@tuf-on-ci-user1"
+   },
+   "fa47289": {
+    "keytype": "ed25519",
+    "keyval": {
+     "public": "fa472895c9756c2b9bcd1440bf867d0fa5c4edee79e9792fa9822be3dd6fcbb3"
+    },
+    "scheme": "ed25519",
+    "x-tuf-on-ci-online-uri": "envvar:LOCAL_TESTING_KEY"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+    ],
+    "threshold": 1
+   },
+   "snapshot": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 365,
+    "x-tuf-on-ci-signing-period": 60
+   },
+   "targets": {
+    "keyids": [
+     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+    ],
+    "threshold": 1
+   },
+   "timestamp": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 2,
+    "x-tuf-on-ci-signing-period": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 1,
+  "x-tuf-on-ci-expiry-period": 365,
+  "x-tuf-on-ci-signing-period": 60
+ }
+}

--- a/tests/expected/delegated/metadata/2.snapshot.json
+++ b/tests/expected/delegated/metadata/2.snapshot.json
@@ -1,0 +1,22 @@
+{
+ "signatures": [
+  {
+   "keyid": "fa47289",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "snapshot",
+  "expires": "2022-02-03T01:02:03Z",
+  "meta": {
+   "delegated.json": {
+    "version": 1
+   },
+   "targets.json": {
+    "version": 2
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 2
+ }
+}

--- a/tests/expected/delegated/metadata/2.targets.json
+++ b/tests/expected/delegated/metadata/2.targets.json
@@ -1,0 +1,42 @@
+{
+ "signatures": [
+  {
+   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "targets",
+  "delegations": {
+   "keys": {
+    "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+     "keytype": "ecdsa",
+     "keyval": {
+      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
+     },
+     "scheme": "ecdsa-sha2-nistp384",
+     "x-tuf-on-ci-keyowner": "@tuf-on-ci-user1"
+    }
+   },
+   "roles": [
+    {
+     "keyids": [
+      "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     ],
+     "name": "delegated",
+     "paths": [
+      "delegated/*"
+     ],
+     "terminating": true,
+     "threshold": 1
+    }
+   ]
+  },
+  "expires": "2022-02-03T01:02:03Z",
+  "spec_version": "1.0.31",
+  "targets": {},
+  "version": 2,
+  "x-tuf-on-ci-expiry-period": 365,
+  "x-tuf-on-ci-signing-period": 60
+ }
+}

--- a/tests/expected/delegated/metadata/timestamp.json
+++ b/tests/expected/delegated/metadata/timestamp.json
@@ -1,0 +1,19 @@
+{
+ "signatures": [
+  {
+   "keyid": "fa47289",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "timestamp",
+  "expires": "2021-02-05T01:02:03Z",
+  "meta": {
+   "snapshot.json": {
+    "version": 2
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 2
+ }
+}


### PR DESCRIPTION
This ballooned a bit (but code is actually removed, the added lines are tests and test expected results).

* Update to securesystemslib 0.30
* This means we don't need a specific sigstore version anymore (in practice we get sigstore 2.0)
* Use the improved sigstore signer import (or "identity registration") in securesystemslib
* Fix a bug related to delegated roles that I found while testing the above
* Add a test for the bug

This should enable us to finally make a PyPI release of tuf-on-ci-signer.

Fixes #88
Fixes #42
Enables fixing #31