### PR TITLE
signer: Fix a special case in import

### DIFF
--- a/signer/tuf_on_ci_sign/import_repo.py
+++ b/signer/tuf_on_ci_sign/import_repo.py
@@ -151,13 +151,13 @@ def import_repo(verbose: int, push: bool, event_name: str, import_file: str | No
             role_data = import_data[rolename]
             if rolename == "root":
                 with repo.edit_root() as root:
-                    ok = _update_expiry(root, role_data) and ok
                     ok = _update_signing(root, role_data) and ok
+                    ok = _update_expiry(root, role_data) and ok
 
                     for online_rolename in ["timestamp", "snapshot"]:
                         role = root.get_delegated_role(online_rolename)
-                        ok = _update_expiry(role, role_data) and ok
                         ok = _update_signing(role, role_data) and ok
+                        ok = _update_expiry(role, role_data) and ok
 
                     ok = _update_keys(root.keys, role_data) and ok
                     if not ok:


### PR DESCRIPTION
If the metadata uses "x-playground-" variables and does not contain x-playground-signing-period for online roles, the import fails because of order of operations (expiry period is already in new format when signing period parsing tries to use the old expiry format).

Figure out signing-period before expiry-period so this special case works.

---

Comment: I think the "x-playground-" support can be removed very soon (not many repos still running with that data) but this is a trivial fix that likely let's me upgrade https://github.com/jku/test-repo-for-playground...
