### PR TITLE
Revert change of artifats path to targets.

### DIFF
--- a/actions/upload-repository/action.yml
+++ b/actions/upload-repository/action.yml
@@ -13,7 +13,7 @@ inputs:
   artifacts_path:
     description: 'relative published artifact path (only useful with gh_pages)'
     required: false
-    default: "artifacts"
+    default: "targets"
 
 runs:
   using: "composite"


### PR DESCRIPTION
When publishing, the targets was moved to /artifacts insteaf of /targets if not specified. As this is a breaking change we should revert that.