### PR TITLE
Adds step summaries for the most important steps

### DIFF
--- a/actions/create-signing-events/action.yml
+++ b/actions/create-signing-events/action.yml
@@ -21,6 +21,11 @@ runs:
         events=$(tuf-on-ci-create-signing-events --push)
         echo events="$events"
         echo events="$events" >> $GITHUB_OUTPUT
+        if [ -z "${events}" ]; then
+            echo "Nothing to prepare" >> $GITHUB_STEP_SUMMARY
+        else
+            echo "Dispatching events for ${events}" >> $GITHUB_STEP_SUMMARY
+        fi
       shell: bash
 
     - name: Dispatch signing event workflow

--- a/actions/online-sign/action.yml
+++ b/actions/online-sign/action.yml
@@ -41,7 +41,7 @@ runs:
         if [[ $GITHUB_SHA == $(git rev-parse HEAD) ]]; then
           echo "ONLINE_SIGNED=false"
           echo "ONLINE_SIGNED=false" >> "$GITHUB_ENV"
-          echo "### Nothing to sign" >> $GITHUB_STEP_SUMMARY"
+          echo "### Nothing to sign" >> "$GITHUB_STEP_SUMMARY"
         else
           echo "ONLINE_SIGNED=true"
           echo "ONLINE_SIGNED=true" >> "$GITHUB_ENV"

--- a/actions/online-sign/action.yml
+++ b/actions/online-sign/action.yml
@@ -41,6 +41,7 @@ runs:
         if [[ $GITHUB_SHA == $(git rev-parse HEAD) ]]; then
           echo "ONLINE_SIGNED=false"
           echo "ONLINE_SIGNED=false" >> "$GITHUB_ENV"
+          echo "### Nothing to sign" >> $GITHUB_STEP_SUMMARY"
         else
           echo "ONLINE_SIGNED=true"
           echo "ONLINE_SIGNED=true" >> "$GITHUB_ENV"
@@ -52,6 +53,7 @@ runs:
       run: |
         git show --oneline --no-patch HEAD
         git push origin HEAD:publish
+        echo "### Online signing finished, will now publish" >> $GITHUB_STEP_SUMMARY
       shell: bash
 
     - id: dispatch-publish-workflow

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -64,9 +64,9 @@ runs:
             pr_url.searchParams.set("body", "Signing event " + process.env.GITHUB_REF_NAME + " is successful and ready to merge.\n\nCloses #" + issue + ".")
             message += "### Signing event is successful\n\n"
             message += "Threshold of signatures has been reached. A [pull request](" + pr_url + ") can be opened."
-            summary = "### Signing event is successful"
+            summary = "Signing event is successful"
           } else {
-            summary = "### Signing event in progress"
+            summary = "Signing event in progress"
           }
 
           github.rest.issues.createComment({

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -33,6 +33,7 @@ runs:
         script: |
           const fs = require('fs')
           message = fs.readFileSync('./status-output').toString()
+          summary = ''
 
           issue = 0
           const repo = context.repo.owner + "/" + context.repo.repo
@@ -63,6 +64,9 @@ runs:
             pr_url.searchParams.set("body", "Signing event " + process.env.GITHUB_REF_NAME + " is successful and ready to merge.\n\nCloses #" + issue + ".")
             message += "### Signing event is successful\n\n"
             message += "Threshold of signatures has been reached. A [pull request](" + pr_url + ") can be opened."
+            summary = "### Signing event is successful"
+          } else {
+            summary = "### Signing event in progress"
           }
 
           github.rest.issues.createComment({
@@ -71,3 +75,5 @@ runs:
             repo: context.repo.repo,
             body: message,
           })
+
+          await core.summary.addHeading(summary).write()

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -18,12 +18,11 @@ runs:
       run: |
         if tuf-on-ci-status >> status-output;  then
           echo "status=success" >> $GITHUB_OUTPUT
-          cat status-output >> "$GITHUB_STEP_SUMMARY"
         else
           echo "status=failure" >> $GITHUB_OUTPUT
-          echo "Failed to get status of event" >> "$GITHUB_STEP_SUMMARY"
         fi
         cat status-output
+        cat status-output >> "$GITHUB_STEP_SUMMARY"
       shell: bash
 
     - id: file-issue

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -18,8 +18,10 @@ runs:
       run: |
         if tuf-on-ci-status >> status-output;  then
           echo "status=success" >> $GITHUB_OUTPUT
+          cat status-output >> "$GITHUB_STEP_SUMMARY"
         else
           echo "status=failure" >> $GITHUB_OUTPUT
+          echo "Failed to get status of event" >> "$GITHUB_STEP_SUMMARY"
         fi
         cat status-output
       shell: bash

--- a/actions/upload-repository/action.yml
+++ b/actions/upload-repository/action.yml
@@ -56,7 +56,7 @@ runs:
       shell: bash
       run: |
         if [ "${{inputs.gh_pages }}" == "true" ]; then
-            echo "Repository deployed to GitHub Pages" >> $GITHUB_STEP_SUMMARY
+            echo "Repository is uploaded and ready to be deployed to GitHub Pages" >> $GITHUB_STEP_SUMMARY
         else
             echo "Repository is uploaded to artifacts" >> $GITHUB_STEP_SUMMARY
         fi

--- a/actions/upload-repository/action.yml
+++ b/actions/upload-repository/action.yml
@@ -51,3 +51,12 @@ runs:
       if: inputs.gh_pages == 'true'
       with:
         path: build/
+
+    - id: status-summary
+      shell: bash
+      run: |
+        if [ "${{inputs.gh_pages }}" == "true" ]; then
+            echo "Repository deployed to GitHub Pages" >> $GITHUB_STEP_SUMMARY
+        else
+            echo "Repoistory is uploaded to artifacts" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/actions/upload-repository/action.yml
+++ b/actions/upload-repository/action.yml
@@ -58,5 +58,5 @@ runs:
         if [ "${{inputs.gh_pages }}" == "true" ]; then
             echo "Repository deployed to GitHub Pages" >> $GITHUB_STEP_SUMMARY
         else
-            echo "Repoistory is uploaded to artifacts" >> $GITHUB_STEP_SUMMARY
+            echo "Repository is uploaded to artifacts" >> $GITHUB_STEP_SUMMARY
         fi

--- a/repo/tuf_on_ci/status.py
+++ b/repo/tuf_on_ci/status.py
@@ -210,7 +210,8 @@ def status(verbose: int, push: bool) -> None:
             msg = "Updates were rejected because the remote contains work that you do"
             found = e.stdout.find(msg)
             if found:
-                print("There are changes in the signing event. Skipping metadata update")
+                m = "There are changes in the signing event. Skipping metadata update"
+                print(m)
             else:
                 print("Git output on error:", e.stdout, e.stderr)
                 raise e

--- a/repo/tuf_on_ci/status.py
+++ b/repo/tuf_on_ci/status.py
@@ -207,7 +207,8 @@ def status(verbose: int, push: bool) -> None:
         except subprocess.CalledProcessError as e:
             # Figure out if this is an error caused by remote being ahead
             # of local branch
-            found = e.stdout.find("Updates were rejected because the remote contains work that you do")
+            msg = "Updates were rejected because the remote contains work that you do"
+            found = e.stdout.find(msg)
             if found:
                 print("Updates on remote, will not push")
             else:

--- a/repo/tuf_on_ci/status.py
+++ b/repo/tuf_on_ci/status.py
@@ -210,7 +210,7 @@ def status(verbose: int, push: bool) -> None:
             msg = "Updates were rejected because the remote contains work that you do"
             found = e.stdout.find(msg)
             if found:
-                print("Updates on remote, will not push")
+                print("There are changes in the signing event. Skipping metadata update")
             else:
                 print("Git output on error:", e.stdout, e.stderr)
                 raise e


### PR DESCRIPTION
Closes https://github.com/theupdateframework/tuf-on-ci/issues/79

Also this PR tries do detect updates on remote when running `tuf-on-ci-status`. If there are updates on remote, it wont print out the complete error message from git, instead it prints out that there are updates on remote, and so will not try to push.

As there are updates on remote, those updates will trigger a new workflow run that exectues `tuf-on-ci-status`, so it's safe to just ignore this error.