### PR TITLE
Release v0.1.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.1.0
 
 NOTE: This is a major API break, users should **not** just upgrade the action versions but
 should replace their workflows with new workflows from tuf-on-ci-template.
@@ -9,6 +9,7 @@ Release contains:
 * Major refactoring of actions: New actions are more logical and enable separating
   publishing fron online signing. The repository now contains a new branch "publish"
   that always points to the newest publishable repository version
+* Improved Sigstore signer registration flow
 * Bug fixes
 
 Upgrade instructions:
@@ -19,6 +20,8 @@ Upgrade instructions:
 * If you use the experimental sigstore online signing: After updating run
   `tuf-on-ci-delegate sign/update-online-key timestamp` re-select sigstore as the signing
   system: This creates a new signing event that is required for online signing to work.
+
+Thanks to contributors Radoslav Dimitrov, Meredith Lancaster and lv291.
 
 ## v0.0.1
 

--- a/repo/pyproject.toml
+++ b/repo/pyproject.toml
@@ -8,7 +8,7 @@ allow-direct-references = true
 
 [project]
 name = "tuf-on-ci"
-version = "0.0.1"
+version = "0.1.0"
 description = "TUF-on-CI repository tools, intended to be executed on a CI system"
 readme = "README.md"
 dependencies = [

--- a/signer/pyproject.toml
+++ b/signer/pyproject.toml
@@ -8,7 +8,7 @@ allow-direct-references = true
 
 [project]
 name = "tuf-on-ci-sign"
-version = "0.0.1"
+version = "0.1.0"
 description = "Signing tools for TUF-on-CI"
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
* My intuition says to not wait for #96 and instead do another release soon
* this should be the first pypi release: possible issues in the publishing pipeline there might lead to needing new releases soon as well
