### PR TITLE
Update tuf version

### DIFF
--- a/repo/pyproject.toml
+++ b/repo/pyproject.toml
@@ -13,7 +13,7 @@ description = "TUF-on-CI repository tools, intended to be executed on a CI syste
 readme = "README.md"
 dependencies = [
   "securesystemslib[azurekms, gcpkms, sigstore, pynacl] ~= 0.30",
-  "tuf ~= 3.0",
+  "tuf ~= 3.1",
   "click ~= 8.1",
 ]
 requires-python = ">=3.10"

--- a/repo/tuf_on_ci/_repository.py
+++ b/repo/tuf_on_ci/_repository.py
@@ -21,6 +21,7 @@ from tuf.api.metadata import (
     Metadata,
     MetaFile,
     Root,
+    Signed,
     Snapshot,
     TargetFile,
     Targets,
@@ -240,31 +241,22 @@ class CIRepository(Repository):
         """
         return MetaFile(self.snapshot().version)
 
-    def open_prev(self, role: str) -> Metadata | None:
-        """Return known good metadata for role (if it exists)"""
-        prev_fname = f"{self._prev_dir}/{role}.json"
-        if os.path.exists(prev_fname):
-            with open(prev_fname, "rb") as f:
-                return Metadata.from_bytes(f.read())
-
-        return None
-
     def _validate_role(self, rolename: str) -> tuple[bool, str | None]:
         """Validate role compatibility with this repository
 
         Returns bool for validity and optional error message"""
-        md = self.open(rolename)
-        prev_md = self.open_prev(rolename)
+        signed: Signed = self.open(rolename).signed
+        known_good = self._known_good(rolename)
 
         # TODO: Current checks are more examples than actual checks
 
         # Make sure version grows if there are actual payload changes
-        if prev_md and prev_md.signed != md.signed:
-            if md.signed.version <= prev_md.signed.version:
-                return False, f"Version {md.signed.version} is not valid for {rolename}"
+        if known_good and known_good != signed:
+            if signed.version <= known_good.version:
+                return False, f"Version {signed.version} is not valid for {rolename}"
 
-        days = md.signed.unrecognized_fields["x-tuf-on-ci-expiry-period"]
-        if md.signed.expires > datetime.utcnow() + timedelta(days=days):
+        days = signed.unrecognized_fields["x-tuf-on-ci-expiry-period"]
+        if signed.expires > datetime.utcnow() + timedelta(days=days):
             return False, f"Expiry date is further than expected {days} days ahead"
 
         # TODO for root:
@@ -308,31 +300,17 @@ class CIRepository(Repository):
 
         return targetfiles
 
-    def _known_good_root(self) -> Root:
-        """Return the Root object from the known-good repository state"""
+    def _known_good(self, rolename: str) -> Root | Targets | None:
+        """Return object from the known-good repository state"""
+        assert rolename not in [Timestamp.type, Snapshot.type]
         assert self._prev_dir is not None
-        prev_path = os.path.join(self._prev_dir, "root.json")
-        if os.path.exists(prev_path):
-            with open(prev_path, "rb") as f:
-                md = Metadata.from_bytes(f.read())
-            assert isinstance(md.signed, Root)
-            return md.signed
-        else:
-            # this role did not exist: return an empty one for comparison purposes
-            return Root()
 
-    def _known_good_targets(self, rolename: str) -> Targets:
-        """Return Targets from the known good version (signing event start point)"""
-        assert self._prev_dir
         prev_path = os.path.join(self._prev_dir, f"{rolename}.json")
-        if os.path.exists(prev_path):
-            with open(prev_path, "rb") as f:
-                md = Metadata.from_bytes(f.read())
-            assert isinstance(md.signed, Targets)
-            return md.signed
-        else:
-            # this role did not exist: return an empty one for comparison purposes
-            return Targets()
+        if not os.path.exists(prev_path):
+            return None
+
+        with open(prev_path, "rb") as f:
+            return Metadata.from_bytes(f.read()).signed
 
     def _get_target_changes(self, rolename: str) -> list[TargetState]:
         """Compare targetfiles in known good version and signing event version:
@@ -343,7 +321,13 @@ class CIRepository(Repository):
 
         changes = []
 
-        known_good_targetfiles = self._known_good_targets(rolename).targets
+        targets = self._known_good(rolename)
+        if targets is None:
+            known_good_targetfiles = {}
+        else:
+            assert isinstance(targets, Targets)
+            known_good_targetfiles = targets.targets
+
         for targetfile in self.targets(rolename).targets.values():
             if targetfile.path not in known_good_targetfiles:
                 # new in signing event
@@ -378,9 +362,8 @@ class CIRepository(Repository):
 
         # If role is root and a previous version exists, verify with that too
         if rolename == Root.type:
-            prev_root_md = self.open_prev(Root.type)
-            if prev_root_md:
-                prev_delegator = prev_root_md.signed
+            prev_delegator = self._known_good(Root.type)
+            if prev_delegator:
                 prev_result = prev_delegator.get_verification_result(rolename, md.signed_bytes, md.signatures)
                 result = result.union(prev_result)
 

--- a/repo/tuf_on_ci/_repository.py
+++ b/repo/tuf_on_ci/_repository.py
@@ -57,12 +57,64 @@ class TargetState:
 
 
 @dataclass
+class VerificationResultWithKeys:
+    """Signature verification result for delegated role metadata.
+
+    Attributes:
+        verified: True, if threshold of signatures is met.
+        signed: Signed delegated Keys.
+        unsigned: Unsigned delegated Keys.
+
+    """
+
+    verified: bool
+    signed: list[Key]
+    unsigned: list[Key]
+
+    @classmethod
+    def from_verification_result(
+        cls, original: VerificationResult, delegator: Root | Targets
+    ):
+        signed = [delegator.get_key(keyid) for keyid in original.signed]
+        unsigned = [delegator.get_key(keyid) for keyid in original.unsigned]
+        return VerificationResultWithKeys(original.verified, signed, unsigned)
+
+    def __bool__(self) -> bool:
+        return self.verified
+
+    def union(
+        self, other: "VerificationResultWithKeys"
+    ) -> "VerificationResultWithKeys":
+        """Combine two verification results.
+
+        Can be used to verify if root metadata is signed by the threshold of
+        keys of previous root and the threshold of keys of itself.
+        """
+        signed = self.signed.copy()
+        signed.extend([s for s in other.signed if s not in signed])
+        unsigned = self.unsigned.copy()
+        unsigned.extend([s for s in other.unsigned if s not in unsigned])
+
+        return VerificationResultWithKeys(
+            self.verified and other.verified, signed, unsigned
+        )
+
+
+@dataclass
 class SigningStatus:
     invites: set[str]  # invites to _delegations_ of the role
-    verification_result: VerificationResult
+    verification_result: VerificationResultWithKeys
     target_changes: list[TargetState]
     valid: bool
     message: str | None
+
+
+def _get_verification_result(
+    delegator: Root | Targets, rolename: str, md: Metadata
+) -> VerificationResultWithKeys:
+    """Helper to get verification results with Keys instead of keyids"""
+    result = delegator.get_verification_result(rolename, md.signed_bytes, md.signatures)
+    return VerificationResultWithKeys.from_verification_result(result, delegator)
 
 
 class SigningEventState:
@@ -111,26 +163,6 @@ class CIRepository(Repository):
 
     def _get_filename(self, role: str) -> str:
         return f"{self._dir}/{role}.json"
-
-    def _get_keys(self, role: str) -> list[Key]:
-        """Return public keys for delegated role
-
-        Note that this will not return all keys required to sign root
-        (only the keys defined in current role).
-        """
-        if role in ["root", "timestamp", "snapshot", "targets"]:
-            delegator = self.root()
-        else:
-            delegator = self.targets()
-
-        r = delegator.get_delegated_role(role)
-        keys = []
-        for keyid in r.keyids:
-            try:
-                keys.append(delegator.get_key(keyid))
-            except ValueError:
-                pass
-        return keys
 
     def open(self, role: str) -> Metadata:
         """Return existing metadata, or create new metadata
@@ -189,7 +221,8 @@ class CIRepository(Repository):
         md.signed.expires = datetime.utcnow() + timedelta(days=expiry_days)
 
         md.signatures.clear()
-        for key in self._get_keys(rolename):
+        unsigned = self._get_verification_result(rolename, md).unsigned
+        for key in unsigned:
             if rolename in ["timestamp", "snapshot"]:
                 uri = key.unrecognized_fields["x-tuf-on-ci-online-uri"]
                 # WORKAROUND while sigstoresigner is not finished
@@ -345,26 +378,29 @@ class CIRepository(Repository):
 
         return changes
 
-
-    def _get_verification_result(self, rolename: str) -> VerificationResult:
+    def _get_verification_result(
+        self, rolename: str, md: Metadata
+    ) -> VerificationResultWithKeys:
         """Return verification result for rolename.
 
-        Take into account that root must be verified by itself and the previous root. 
+        Take into account that root must be verified by itself and the previous root.
         """
-        md = self.open(rolename)
-
-        if rolename in [Root.type, Targets.type]:
-            delegator:Root | Targets = self.root()
+        if rolename == Root.type:
+            # md may be modified if we're in close() persisting a new root:
+            # we use that root as delegator instead of self.root()
+            delegator: Root | Targets = md.signed
+        elif rolename in [Timestamp.type, Snapshot.type, Targets.type]:
+            delegator = self.root()
         else:
             delegator = self.targets()
 
-        result = delegator.get_verification_result(rolename, md.signed_bytes, md.signatures)
+        result = _get_verification_result(delegator, rolename, md)
 
         # If role is root and a previous version exists, verify with that too
         if rolename == Root.type:
             prev_delegator = self._known_good(Root.type)
             if prev_delegator:
-                prev_result = prev_delegator.get_verification_result(rolename, md.signed_bytes, md.signatures)
+                prev_result = _get_verification_result(prev_delegator, rolename, md)
                 result = result.union(prev_result)
 
         return result
@@ -379,8 +415,8 @@ class CIRepository(Repository):
             delegation_names = [Root.type, Targets.type]
         elif rolename == Targets.type:
             targets = self.targets()
-            if targets.delegations:
-                delegation_names = targets.delegations.roles.keys()
+            if targets.delegations and targets.delegations.roles:
+                delegation_names = list(targets.delegations.roles.keys())
 
         for delegation_name in delegation_names:
             invites.update(self.state.invited_signers_for_role(delegation_name))
@@ -401,7 +437,8 @@ class CIRepository(Repository):
         invites = self._get_invites(rolename)
 
         # Find out verification status (inluding which keys have signed)
-        verification_result = self._get_verification_result(rolename)
+        md = self.open(rolename)
+        verification_result = self._get_verification_result(rolename, md)
 
         # Document changes to targets metadata in this signing event
         target_changes = self._get_target_changes(rolename)
@@ -412,9 +449,7 @@ class CIRepository(Repository):
             # Repository validation (metadata may be valid but still not acceptable)
             valid, msg = self._validate_role(rolename)
 
-        return SigningStatus(
-            invites, verification_result, target_changes, valid, msg
-        )
+        return SigningStatus(invites, verification_result, target_changes, valid, msg)
 
     def build(self, metadata_path: str, artifact_path: str | None):
         """Build a publishable directory of metadata and (optionally) artifacts"""

--- a/repo/tuf_on_ci/_repository.py
+++ b/repo/tuf_on_ci/_repository.py
@@ -76,7 +76,9 @@ class VerificationResultWithKeys:
         cls, original: VerificationResult, delegator: Root | Targets
     ):
         signed = [delegator.get_key(keyid) for keyid in original.signed]
+        signed.sort(key=lambda key: key.keyid)
         unsigned = [delegator.get_key(keyid) for keyid in original.unsigned]
+        unsigned.sort(key=lambda key: key.keyid)
         return VerificationResultWithKeys(original.verified, signed, unsigned)
 
     def __bool__(self) -> bool:

--- a/repo/tuf_on_ci/_repository.py
+++ b/repo/tuf_on_ci/_repository.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 from enum import Enum, unique
 from glob import glob
 
-from securesystemslib.exceptions import UnverifiedSignatureError
 from securesystemslib.signer import (
     KEY_FOR_TYPE_AND_SCHEME,
     Signature,
@@ -26,6 +25,7 @@ from tuf.api.metadata import (
     TargetFile,
     Targets,
     Timestamp,
+    VerificationResult,
 )
 from tuf.api.serialization.json import JSONSerializer
 from tuf.repository import AbortEdit, Repository
@@ -58,9 +58,7 @@ class TargetState:
 @dataclass
 class SigningStatus:
     invites: set[str]  # invites to _delegations_ of the role
-    signed: set[str]
-    missing: set[str]
-    threshold: int
+    verification_result: VerificationResult
     target_changes: list[TargetState]
     valid: bool
     message: str | None
@@ -263,9 +261,7 @@ class CIRepository(Repository):
 
         return None
 
-    def _validate_role(
-        self, delegator: Root | Targets, rolename: str
-    ) -> tuple[bool, str | None]:
+    def _validate_role(self, rolename: str) -> tuple[bool, str | None]:
         """Validate role compatibility with this repository
 
         Returns bool for validity and optional error message"""
@@ -294,11 +290,7 @@ class CIRepository(Repository):
         # TODO for delegated targets:
         # * check there are no delegations
         # * check that target files in metadata match the files in targets/
-
-        try:
-            delegator.verify_delegate(rolename, md.signed_bytes, md.signatures)
-        except UnsignedMetadataError:
-            return False, None
+        # * check that target files in metadata are in the delegated path
 
         return True, None
 
@@ -381,9 +373,50 @@ class CIRepository(Repository):
 
         return changes
 
-    def _get_signing_status(
-        self, rolename: str, known_good: bool
-    ) -> SigningStatus | None:
+
+    def _get_verification_result(self, rolename: str) -> VerificationResult:
+        """Return verification result for rolename.
+
+        Take into account that root must be verified by itself and the previous root. 
+        """
+        md = self.open(rolename)
+
+        if rolename in [Root.type, Targets.type]:
+            delegator:Root | Targets = self.root()
+        else:
+            delegator = self.targets()
+
+        result = delegator.get_verification_result(rolename, md.signed_bytes, md.signatures)
+
+        # If role is root and a previous version exists, verify with that too
+        if rolename == Root.type:
+            prev_root_md = self.open_prev(Root.type)
+            if prev_root_md:
+                prev_delegator = prev_root_md.signed
+                prev_result = prev_delegator.get_verification_result(rolename, md.signed_bytes, md.signatures)
+                result = result.union(prev_result)
+
+        return result
+
+    def _get_invites(self, rolename: str) -> set[str]:
+        """Return invites for roles delegations."""
+        invites = set()
+
+        # Build list of invites to all delegated roles of rolename
+        delegation_names = []
+        if rolename == Root.type:
+            delegation_names = [Root.type, Targets.type]
+        elif rolename == Targets.type:
+            targets = self.targets()
+            if targets.delegations:
+                delegation_names = targets.delegations.roles.keys()
+
+        for delegation_name in delegation_names:
+            invites.update(self.state.invited_signers_for_role(delegation_name))
+
+        return invites
+
+    def status(self, rolename: str) -> SigningStatus:
         """Build signing status for role.
 
         This method relies on event state (.signing-event-state) to be accurate.
@@ -392,80 +425,25 @@ class CIRepository(Repository):
         there is no known good version yet.
         """
         invites = set()
-        sigs = set()
-        missing_sigs = set()
-        md = self.open(rolename)
-
-        # Find delegating metadata. For root handle the special case of known good
-        # delegating metadata.
-        delegator: Root | Targets
-        if known_good:
-            if rolename != "root":
-                # Not root role: known good signing status not needed
-                return None
-
-            prev_root_md: Metadata[Root] | None = self.open_prev("root")
-            if not prev_root_md:
-                # No known-good root exists yet
-                return None
-
-            delegator = prev_root_md.signed
-        elif rolename == "root":
-            delegator = self.root()
-        elif rolename == "targets":
-            delegator = self.root()
-        else:
-            delegator = self.targets()
 
         # Build list of invites to all delegated roles of rolename
-        delegation_names = []
-        if rolename == "root":
-            delegation_names = ["root", "targets"]
-        elif rolename == "targets":
-            if md.signed.delegations:
-                delegation_names = md.signed.delegations.roles.keys()
-        for delegation_name in delegation_names:
-            invites.update(self.state.invited_signers_for_role(delegation_name))
+        invites = self._get_invites(rolename)
 
-        role = delegator.get_delegated_role(rolename)
-
-        # Build lists of signed signers and not signed signers
-        payload = md.signed_bytes
-        for key in self._get_keys(rolename, known_good):
-            keyowner = key.unrecognized_fields["x-tuf-on-ci-keyowner"]
-            try:
-                key.verify_signature(md.signatures[key.keyid], payload)
-                sigs.add(keyowner)
-            except (KeyError, UnverifiedSignatureError):
-                missing_sigs.add(keyowner)
+        # Find out verification status (inluding which keys have signed)
+        verification_result = self._get_verification_result(rolename)
 
         # Document changes to targets metadata in this signing event
         target_changes = self._get_target_changes(rolename)
 
-        # Just to be sure: double check that delegation threshold is reached
-        if invites:
+        if invites or not verification_result.verified:
             valid, msg = False, None
         else:
-            valid, msg = self._validate_role(delegator, rolename)
+            # Repository validation (metadata may be valid but still not acceptable)
+            valid, msg = self._validate_role(rolename)
 
         return SigningStatus(
-            invites, sigs, missing_sigs, role.threshold, target_changes, valid, msg
+            invites, verification_result, target_changes, valid, msg
         )
-
-    def status(self, rolename: str) -> tuple[SigningStatus, SigningStatus | None]:
-        """Returns signing status for role.
-
-        In case of root, another SigningStatus may be returned for the previous
-        'known good' root.
-        Uses .signing-event-state file."""
-        if rolename in ["timestamp", "snapshot"]:
-            raise ValueError("Not supported for online metadata")
-
-        known_good_status = self._get_signing_status(rolename, known_good=True)
-        signing_event_status = self._get_signing_status(rolename, known_good=False)
-        assert signing_event_status is not None
-
-        return signing_event_status, known_good_status
 
     def build(self, metadata_path: str, artifact_path: str | None):
         """Build a publishable directory of metadata and (optionally) artifacts"""

--- a/repo/tuf_on_ci/_repository.py
+++ b/repo/tuf_on_ci/_repository.py
@@ -27,7 +27,7 @@ from tuf.api.metadata import (
     Targets,
     Timestamp,
 )
-from tuf.api.serialization.json import CanonicalJSONSerializer, JSONSerializer
+from tuf.api.serialization.json import JSONSerializer
 from tuf.repository import AbortEdit, Repository
 
 # sigstore is not a supported key by default
@@ -216,9 +216,8 @@ class CIRepository(Repository):
                 md.signatures[key.keyid] = Signature(key.keyid, "")
 
         if rolename in ["timestamp", "snapshot"]:
-            root_md: Metadata[Root] = self.open("root")
             # repository should never write unsigned online roles
-            root_md.verify_delegate(rolename, md)
+            self.root().verify_delegate(rolename, md.signed_bytes, md.signatures)
 
         filename = self._get_filename(rolename)
         data = md.to_bytes(JSONSerializer())
@@ -265,7 +264,7 @@ class CIRepository(Repository):
         return None
 
     def _validate_role(
-        self, delegator: Metadata, rolename: str
+        self, delegator: Root | Targets, rolename: str
     ) -> tuple[bool, str | None]:
         """Validate role compatibility with this repository
 
@@ -297,7 +296,7 @@ class CIRepository(Repository):
         # * check that target files in metadata match the files in targets/
 
         try:
-            delegator.verify_delegate(rolename, md)
+            delegator.verify_delegate(rolename, md.signed_bytes, md.signatures)
         except UnsignedMetadataError:
             return False, None
 
@@ -399,19 +398,24 @@ class CIRepository(Repository):
 
         # Find delegating metadata. For root handle the special case of known good
         # delegating metadata.
+        delegator: Root | Targets
         if known_good:
-            delegator = None
-            if rolename == "root":
-                delegator = self.open_prev("root")
-            if not delegator:
-                # Not root role or there is no known-good root metadata yet
+            if rolename != "root":
+                # Not root role: known good signing status not needed
                 return None
+
+            prev_root_md: Metadata[Root] | None = self.open_prev("root")
+            if not prev_root_md:
+                # No known-good root exists yet
+                return None
+
+            delegator = prev_root_md.signed
         elif rolename == "root":
-            delegator = self.open("root")
+            delegator = self.root()
         elif rolename == "targets":
-            delegator = self.open("root")
+            delegator = self.root()
         else:
-            delegator = self.open("targets")
+            delegator = self.targets()
 
         # Build list of invites to all delegated roles of rolename
         delegation_names = []
@@ -423,13 +427,13 @@ class CIRepository(Repository):
         for delegation_name in delegation_names:
             invites.update(self.state.invited_signers_for_role(delegation_name))
 
-        role = delegator.signed.get_delegated_role(rolename)
+        role = delegator.get_delegated_role(rolename)
 
         # Build lists of signed signers and not signed signers
+        payload = md.signed_bytes
         for key in self._get_keys(rolename, known_good):
             keyowner = key.unrecognized_fields["x-tuf-on-ci-keyowner"]
             try:
-                payload = CanonicalJSONSerializer().serialize(md.signed)
                 key.verify_signature(md.signatures[key.keyid], payload)
                 sigs.add(keyowner)
             except (KeyError, UnverifiedSignatureError):
@@ -533,17 +537,18 @@ class CIRepository(Repository):
         false in this case: this is useful when repository decides if it needs a new
         online role version.
         """
-        role_md = self.open(rolename)
+        md = self.open(rolename)
         if rolename in ["root", "timestamp", "snapshot", "targets"]:
-            delegator = self.open("root")
+            delegator: Root | Targets = self.root()
         else:
-            delegator = self.open("targets")
+            delegator = self.targets()
+
         try:
-            delegator.verify_delegate(rolename, role_md)
+            delegator.verify_delegate(rolename, md.signed_bytes, md.signatures)
         except UnsignedMetadataError:
             return False
 
         signing_days, _ = self.signing_expiry_period(rolename)
         delta = timedelta(days=signing_days)
 
-        return datetime.utcnow() + delta < role_md.signed.expires
+        return datetime.utcnow() + delta < md.signed.expires

--- a/repo/tuf_on_ci/_repository.py
+++ b/repo/tuf_on_ci/_repository.py
@@ -111,34 +111,22 @@ class CIRepository(Repository):
     def _get_filename(self, role: str) -> str:
         return f"{self._dir}/{role}.json"
 
-    def _get_keys(self, role: str, known_good: bool = False) -> list[Key]:
+    def _get_keys(self, role: str) -> list[Key]:
         """Return public keys for delegated role
 
-        If known_good is True, use the keys defined in known good delegator.
-        Otherwise use keys defined in the signing event delegator.
+        Note that this will not return all keys required to sign root
+        (only the keys defined in current role).
         """
         if role in ["root", "timestamp", "snapshot", "targets"]:
-            if known_good:
-                delegator: Root | Targets = self._known_good_root()
-            else:
-                delegator = self.root()
+            delegator = self.root()
         else:
-            if known_good:
-                delegator = self._known_good_targets("targets")
-            else:
-                delegator = self.targets()
+            delegator = self.targets()
 
         r = delegator.get_delegated_role(role)
         keys = []
         for keyid in r.keyids:
             try:
-                key = delegator.get_key(keyid)
-                if known_good and "x-tuf-on-ci-keyowner" not in key.unrecognized_fields:
-                    # this is allowed for repo import case: we cannot identify known
-                    # good keys and have to trust that delegations have not changed
-                    continue
-
-                keys.append(key)
+                keys.append(delegator.get_key(keyid))
             except ValueError:
                 pass
         return keys

--- a/repo/tuf_on_ci/status.py
+++ b/repo/tuf_on_ci/status.py
@@ -103,8 +103,10 @@ def _role_status(repo: CIRepository, role: str, event_name) -> bool:
             f"`tuf-on-ci-sign {event_name}`"
         )
     else:
-        signed = status.verification_result.signed
-        unsigned = status.verification_result.unsigned
+        keys = status.verification_result.signed
+        signed = [k.unrecognized_fields["x-tuf-on-ci-keyowner"] for k in keys]
+        keys = status.verification_result.unsigned
+        unsigned = [k.unrecognized_fields["x-tuf-on-ci-keyowner"] for k in keys]
         if status.target_changes:
             click.echo(f"Role `{role}` contains following artifact changes:")
             for target_state in status.target_changes:
@@ -121,9 +123,7 @@ def _role_status(repo: CIRepository, role: str, event_name) -> bool:
                 f"Role `{role}` Role has not been signed threshold of signers yet. "
             )
             if signed:
-                click.echo(
-                    f"Currently it is signed by ({', '.join(signed)})."
-                )
+                click.echo(f"Currently it is signed by ({', '.join(signed)}).")
             else:
                 click.echo("Currently it is signed by no-one.")
 

--- a/repo/tuf_on_ci/status.py
+++ b/repo/tuf_on_ci/status.py
@@ -87,20 +87,9 @@ def _find_changed_target_roles(
 
 
 def _role_status(repo: CIRepository, role: str, event_name) -> bool:
-    status, prev_status = repo.status(role)
-    role_is_valid = status.valid
-    sig_counts = f"{len(status.signed)}/{status.threshold}"
-    signed = status.signed
-    missing = status.missing
+    status = repo.status(role)
 
-    # Handle the additional status for the possible previous, known good root version:
-    if prev_status:
-        role_is_valid = role_is_valid and prev_status.valid
-        sig_counts = f"{len(prev_status.signed)}/{prev_status.threshold} ({sig_counts})"
-        signed = signed | prev_status.signed
-        missing = missing | prev_status.missing
-
-    if role_is_valid and not status.invites:
+    if status.valid:
         emoji = "white_check_mark"
     else:
         emoji = "x"
@@ -113,29 +102,33 @@ def _role_status(repo: CIRepository, role: str, event_name) -> bool:
             "Invitees can accept the invitations by running "
             f"`tuf-on-ci-sign {event_name}`"
         )
-
-    if not status.invites:
+    else:
+        signed = status.verification_result.signed
+        unsigned = status.verification_result.unsigned
         if status.target_changes:
             click.echo(f"Role `{role}` contains following artifact changes:")
             for target_state in status.target_changes:
                 click.echo(f" * {target_state}")
             click.echo("")
 
-        if role_is_valid:
+        if status.valid:
             click.echo(
-                f"Role `{role}` is verified and signed by {sig_counts} signers "
+                f"Role `{role}` is verified and signed by threshold of signers "
                 f"({', '.join(signed)})."
             )
-        elif signed:
-            click.echo(
-                f"Role `{role}` is not yet verified. It is signed by {sig_counts} "
-                f"signers ({', '.join(signed)})."
-            )
         else:
-            click.echo(f"Role `{role}` is unsigned and not yet verified")
+            click.echo(
+                f"Role `{role}` Role has not been signed threshold of signers yet. "
+            )
+            if signed:
+                click.echo(
+                    f"Currently it is signed by ({', '.join(signed)})."
+                )
+            else:
+                click.echo("Currently it is signed by no-one.")
 
-        if missing:
-            click.echo(f"Still missing signatures from {', '.join(missing)}")
+        if unsigned:
+            click.echo(f"Still missing signatures from {', '.join(unsigned)}")
             click.echo(
                 "Signers can sign these changes by running "
                 f"`tuf-on-ci-sign {event_name}`"
@@ -144,7 +137,7 @@ def _role_status(repo: CIRepository, role: str, event_name) -> bool:
     if status.message:
         click.echo(f"**Error**: {status.message}")
 
-    return role_is_valid and not status.invites
+    return status.valid
 
 
 @click.command()  # type: ignore[arg-type]

--- a/repo/tuf_on_ci/status.py
+++ b/repo/tuf_on_ci/status.py
@@ -120,7 +120,7 @@ def _role_status(repo: CIRepository, role: str, event_name) -> bool:
             )
         else:
             click.echo(
-                f"Role `{role}` Role has not been signed threshold of signers yet. "
+                f"Role `{role}` Role has not been signed by threshold of signers yet. "
             )
             if signed:
                 click.echo(f"Currently it is signed by ({', '.join(signed)}).")
@@ -128,7 +128,7 @@ def _role_status(repo: CIRepository, role: str, event_name) -> bool:
                 click.echo("Currently it is signed by no-one.")
 
         if unsigned:
-            click.echo(f"Still missing signatures from {', '.join(unsigned)}")
+            click.echo(f"Still missing signatures from {', '.join(unsigned)}.")
             click.echo(
                 "Signers can sign these changes by running "
                 f"`tuf-on-ci-sign {event_name}`"
@@ -136,7 +136,6 @@ def _role_status(repo: CIRepository, role: str, event_name) -> bool:
 
     if status.message:
         click.echo(f"**Error**: {status.message}")
-
     return status.valid
 
 

--- a/signer/pyproject.toml
+++ b/signer/pyproject.toml
@@ -13,7 +13,7 @@ description = "Signing tools for TUF-on-CI"
 readme = "README.md"
 dependencies = [
   "securesystemslib[gcpkms,hsm,sigstore] ~= 0.30",
-  "tuf ~= 3.0",
+  "tuf ~= 3.1",
   "click ~= 8.1",
 ]
 requires-python = ">=3.10"

--- a/signer/tuf_on_ci_sign/_signer_repository.py
+++ b/signer/tuf_on_ci_sign/_signer_repository.py
@@ -33,7 +33,7 @@ from tuf.api.metadata import (
     Signed,
     Targets,
 )
-from tuf.api.serialization.json import CanonicalJSONSerializer, JSONSerializer
+from tuf.api.serialization.json import JSONSerializer
 from tuf.repository import AbortEdit, Repository
 
 from tuf_on_ci_sign._user import User
@@ -150,8 +150,7 @@ class SignerRepository(Repository):
             keyowner = key.unrecognized_fields["x-tuf-on-ci-keyowner"]
             if keyowner == self.user.name:
                 try:
-                    payload = CanonicalJSONSerializer().serialize(md.signed)
-                    key.verify_signature(md.signatures[key.keyid], payload)
+                    key.verify_signature(md.signatures[key.keyid], md.signed_bytes)
                 except (KeyError, UnverifiedSignatureError):
                     return True
 
@@ -162,8 +161,7 @@ class SignerRepository(Repository):
                 keyowner = key.unrecognized_fields["x-tuf-on-ci-keyowner"]
                 if keyowner == self.user.name:
                     try:
-                        payload = CanonicalJSONSerializer().serialize(md.signed)
-                        key.verify_signature(md.signatures[key.keyid], payload)
+                        key.verify_signature(md.signatures[key.keyid], md.signed_bytes)
                     except (KeyError, UnverifiedSignatureError):
                         return True
 

--- a/tests/expected/target-file-changes/metadata/3.targets.json
+++ b/tests/expected/target-file-changes/metadata/3.targets.json
@@ -1,11 +1,11 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198",
    "sig": "XXX"
   },
   {
-   "keyid": "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198",
+   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
    "sig": "XXX"
   }
  ],


### PR DESCRIPTION
Upgrade doesn't strictly speaking require any changes but I wanted to use the new get_verification_result() to test it...

This turns out to be much more work than I expected (this only handles repo codebase, not signer): 
* VerificationResult containing keyids turned out to be less useful: I added a wrapper VerificationResultWithKeys but would like to change the upstream VerificationResult in the end
* I've modified close() to use VerificationResult as well: this had a unexpected side effect where the order of keys was not reproducible (see sort() calls in VerificationResultWithKeys)
* we can remove `open_prev()` now: the simpler `_known_good(self, rolename: str) -> Root | Targets | None` works in all cases
* refactored `_get_signing_status()` so it's smaller and calls separate methods for finding invites and getting verification results
* the `status()` method was refactored a bit but the main change is that VerificationResultWithKeys contains Keys: code needs to lookup the signer name in the keys 

cc @lukpueh let's have a look at this at some point
