### PR TITLE
Release v0.2.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.2.0
+
+* GitHub actions now output step summaries: these are visible in workflow
+  run pages on Github (#96)
+* Improved output in signing event status comments (#101)
+* Fixed online signing with ambient Sigstore identity, which broke in 0.1.0
+  (#118)
+
+Upgrade instructions from v0.1.0:
+ * Dependabot version bump can be accepted as is
+
 ## v0.1.0
 
 NOTE: This is a major API break, users should **not** just upgrade the action versions but

--- a/repo/pyproject.toml
+++ b/repo/pyproject.toml
@@ -8,7 +8,7 @@ allow-direct-references = true
 
 [project]
 name = "tuf-on-ci"
-version = "0.1.0"
+version = "0.2.0"
 description = "TUF-on-CI repository tools, intended to be executed on a CI system"
 readme = "README.md"
 dependencies = [

--- a/signer/pyproject.toml
+++ b/signer/pyproject.toml
@@ -8,7 +8,7 @@ allow-direct-references = true
 
 [project]
 name = "tuf-on-ci-sign"
-version = "0.1.0"
+version = "0.2.0"
 description = "Signing tools for TUF-on-CI"
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
Bug fix release. signer actually has no changes but the release process currently can't handle not releasing signer as well so both get a version bump.