### PR TITLE
Verify that correct version is published.

### DIFF
--- a/actions/online-sign/action.yml
+++ b/actions/online-sign/action.yml
@@ -69,6 +69,6 @@ runs:
             workflow_id: 'publish.yml',
             ref: 'publish',
             inputs: {
-              ref: '${{ steps.move-publish-branch.outputs.rev }}',
+              ref: 'a'+'${{ steps.move-publish-branch.outputs.rev }}',
             },
           })

--- a/actions/online-sign/action.yml
+++ b/actions/online-sign/action.yml
@@ -69,6 +69,6 @@ runs:
             workflow_id: 'publish.yml',
             ref: 'publish',
             inputs: {
-              ref: 'a'+'${{ steps.move-publish-branch.outputs.rev }}',
+              ref: '${{ steps.move-publish-branch.outputs.rev }}',
             },
           })

--- a/actions/online-sign/action.yml
+++ b/actions/online-sign/action.yml
@@ -69,6 +69,6 @@ runs:
             workflow_id: 'publish.yml',
             ref: 'publish',
             inputs: {
-              ref: ${{ steps.move-publish-branch.outputs.rev }},
+              ref: '${{ steps.move-publish-branch.outputs.rev }}',
             },
           })

--- a/actions/online-sign/action.yml
+++ b/actions/online-sign/action.yml
@@ -53,6 +53,7 @@ runs:
       run: |
         git show --oneline --no-patch HEAD
         git push origin HEAD:publish
+        echo "rev=`git rev-parse HEAD`" >> $GITHUB_OUTPUT
         echo "### Online signing finished, will now publish" >> $GITHUB_STEP_SUMMARY
       shell: bash
 
@@ -67,4 +68,7 @@ runs:
             repo: context.repo.repo,
             workflow_id: 'publish.yml',
             ref: 'publish',
+            inputs: {
+              ref: ${{ steps.move-publish-branch.outputs.rev }},
+            },
           })

--- a/actions/upload-repository/action.yml
+++ b/actions/upload-repository/action.yml
@@ -14,11 +14,17 @@ inputs:
     description: 'relative published artifact path (only useful with gh_pages)'
     required: false
     default: "targets"
+  ref:
+    description: 'Ref to clone'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        ref: ${{ inputs.ref }}
 
     - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236
       with:


### PR DESCRIPTION
Closes https://github.com/theupdateframework/tuf-on-ci/issues/126

This is 1/2 PRs, the other is against the template repo as it contains an update to the workflow.

During the online sign action, the produced commit is saved, and passed as an input parameter to the deploy workflow. The deploy workflow uses this ref when checking out the repository. This ref can also be set during manual invocation of the publish workflow. If nothing is provided the mos recent commit is used (the default behaviour in the checkout action).
If the commit from the signing action is not reachable (i.e due to a delay in GitHub) the checkout action fails, and abort the deployment. This is an actionable event and the action can so be re-run.

An example signing: https://github.com/kommendorkapten/tuf-repo-test-2/actions/runs/6877640752/job/18705952685#step:2:383

and the corresponding publish:
https://github.com/kommendorkapten/tuf-repo-test-2/actions/runs/6877751166/job/18705966971#step:2:10