### PR TITLE
Push fix

### DIFF
--- a/repo/tuf_on_ci/status.py
+++ b/repo/tuf_on_ci/status.py
@@ -198,16 +198,18 @@ def status(verbose: int, push: bool) -> None:
                 roles.insert(0, toplevel)
 
         # Update metadata if necessary. Output the roles current status
+        updated = False
         for role in roles:
             if repo.update_targets(role):
                 # metadata and artifacts are not in sync
                 msg = f"Update targets metadata for role {role}"
                 _git(["commit", "-m", msg, "--", f"metadata/{role}.json"])
+                updated = True
 
             if not _role_status(repo, role, event_name):
                 success = False
 
-    if push:
+    if push and updated:
         try:
             _git(["push", "origin", event_name])
         except subprocess.CalledProcessError as e:

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -467,7 +467,7 @@ repo_publish()
     tuf-on-ci-build-repository --metadata $PUBLISH_DIR/metadata --artifacts $PUBLISH_DIR/targets  >> $REPO_DIR/out
 
     # the expected results cannot contain empty dirs because of git: remove empty dir here too
-    rmdir --ignore-fail-on-non-empty "$PUBLISH_DIR/targets"
+    find "$PUBLISH_DIR/targets" -type d -empty -delete
 }
 
 setup_test() {


### PR DESCRIPTION
* Only push if there actually was any changes to the targets metadata
* Ignore GNU specific flags (allows `e2e.sh` go run on any Unix)