### PR TITLE
Support custom GitHub tokens

### DIFF
--- a/actions/create-signing-events/action.yml
+++ b/actions/create-signing-events/action.yml
@@ -35,6 +35,7 @@ runs:
       shell: bash
 
     - name: Dispatch signing event workflow
+      # dispatch if using default token: otherwise create-signing-events step has already triggered push events
       if: inputs.token == github.token && steps.create-signing-events.outputs.events != ''
       env:
         EVENTS: ${{ steps.create-signing-events.outputs.events }}

--- a/actions/create-signing-events/action.yml
+++ b/actions/create-signing-events/action.yml
@@ -1,11 +1,17 @@
 name: 'Create signing events'
 description: 'Create signing events for offline signed metadata that is about to expire'
 
+inputs:
+  token:
+    description: 'GitHub token'
+    required: true
+
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
+        token: ${{ inputs.token }}
         fetch-depth: 0
 
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
@@ -34,6 +40,7 @@ runs:
         EVENTS: ${{ steps.create-signing-events.outputs.events }}
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       with:
+        github-token: ${{ inputs.token }}
         script: |
           console.log('Dispatching events: ', process.env.EVENTS)
           process.env.EVENTS.trim().split(' ').forEach(event => {

--- a/actions/create-signing-events/action.yml
+++ b/actions/create-signing-events/action.yml
@@ -35,7 +35,7 @@ runs:
       shell: bash
 
     - name: Dispatch signing event workflow
-      if: steps.create-signing-events.outputs.events != ''
+      if: inputs.token == github.token && steps.create-signing-events.outputs.events != ''
       env:
         EVENTS: ${{ steps.create-signing-events.outputs.events }}
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea

--- a/actions/online-sign/action.yml
+++ b/actions/online-sign/action.yml
@@ -2,6 +2,9 @@ name: "Online sign"
 description: "Creates a snapshot and timestamp if needed, moves publish branch if needed"
 
 inputs:
+  token:
+    description: 'GitHub token'
+    required: true
   gcp_workload_identity_provider:
     description: "Google Cloud workload identity provider"
     required: false
@@ -24,6 +27,7 @@ runs:
   steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
+        token: ${{ inputs.token }}
         fetch-depth: 0
 
     - name: Authenticate to Google Cloud
@@ -76,6 +80,7 @@ runs:
       if: github.event_name != 'schedule' || env.ONLINE_SIGNED == 'true'
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
+        github-token: ${{ inputs.token }}
         script: |
           console.log('Dispatching publish workflow')
           github.rest.actions.createWorkflowDispatch({

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -1,6 +1,21 @@
 name: 'Signing event'
 description: 'TUF-on-CI Signing event management'
 
+# This action is called from signing-event workflow, which is dispatched in multiple ways
+# depending on the type of token provided in inputs.
+#
+# 1. create-signing-events action creates a new signing event branch
+#     * When using a custom token this triggers push event handler
+#     * When using the default GitHub token the action calls createWorkflowDispatch()
+# 2. A signer pushes artifact changes to a signing event branch
+#     * This triggers push event handler
+# 3. This action (signing-event) makes a metadata change in update_targets step as a result of an artifact change
+#     * When using a custom token this triggers push event handler
+#     * When using the default GitHub token the action calls createWorkflowDispatch()
+#
+# Cases 1 & 3 lead to status step running. Case 2 leads to skipping status step, but
+# triggering case 3 immediately afterwards.
+
 inputs:
   token:
     description: 'GitHub token'
@@ -21,7 +36,19 @@ runs:
     - run: pip install $GITHUB_ACTION_PATH/../../repo/
       shell: bash
 
+    - id: update_targets
+      run: |
+        if tuf-on-ci-update-targets >> status-output;  then
+          echo "targets_updated=true" >> $GITHUB_OUTPUT
+        else
+          echo "targets_updated=false" >> $GITHUB_OUTPUT
+        fi
+        cat status-output
+        cat status-output >> "$GITHUB_STEP_SUMMARY"
+      shell: bash
+
     - id: status
+      if: steps.update_targets.outputs.targets_updated != 'true'
       run: |
         if tuf-on-ci-status >> status-output;  then
           echo "status=success" >> $GITHUB_OUTPUT
@@ -85,3 +112,17 @@ runs:
           })
 
           await core.summary.addHeading(summary).write()
+
+    - name: Dispatch another signing event workflow
+      if: inputs.token == github.token && steps.update_targets.outputs.targets_updated == 'true'
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          console.log('Dispatching another signing event workflow after a targets metadata update')
+          github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'signing-event.yml',
+            ref: process.env.GITHUB_REF_NAME,
+          })

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -1,10 +1,17 @@
 name: 'Signing event'
 description: 'TUF-on-CI Signing event management'
+
+inputs:
+  token:
+    description: 'GitHub token'
+    required: true
+
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
+        token: ${{ inputs.token }}
         fetch-depth: 0
 
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
@@ -30,6 +37,7 @@ runs:
       env:
         STATUS: ${{ steps.status.outputs.status }}
       with:
+        github-token: ${{ inputs.token }}
         script: |
           const fs = require('fs')
           message = fs.readFileSync('./status-output').toString()

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -114,6 +114,7 @@ runs:
           await core.summary.addHeading(summary).write()
 
     - name: Dispatch another signing event workflow
+      # dispatch if using default token: otherwise update_targets step has already triggered a push event
       if: inputs.token == github.token && steps.update_targets.outputs.targets_updated == 'true'
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       with:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+NOTE: This is a major Actions API break, users should **not** just upgrade the action
+versions but should instead replace `create-signing-events.yml`, `online-sign.yml` and
+`signing-event.yml` with workflows from tuf-on-ci-template.
+
+Changes
+* Support for custom GitHub tokens: see [REPOSITORY-MAINTENANCE.md].
+
+Upgrade instructions from v0.3.0:
+* We recommend replacing `create-signing-events.yml`, `online-sign.yml` and
+  `signing-event.yml` with workflows from tuf-on-ci-template to ensure workflows
+  stay compatible with the actions
+
 ## v0.3.0
 
 NOTE: This is a major API break, users should **not** just upgrade the action versions but

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -39,10 +39,10 @@ manually after inspection and it will work as if the push was done by the tool i
 
 ### Debugging repository tools
 
-The same tool (`tuf-on-ci-status`) that runs during the signing event automation
-can be run locally to inspect the current status of the signing event branch. Note
-that the repository tools only operate on current commit (unlike the signing tools 
-that always checkout the remote branch) 
+The same tools (`tuf-on-ci-status`, `tuf-on-ci-update-targets`) that run during the
+signing event automation can be run locally to inspect the current status of the signing
+event branch. Note that the repository tools only operate on current commit (unlike the
+signing tools that always checkout the remote branch).
 
 As an example, this would be the markdown output when an open invitation exists
 for a new user to become a root key holder:

--- a/docs/REPOSITORY-MAINTENANCE.md
+++ b/docs/REPOSITORY-MAINTENANCE.md
@@ -107,7 +107,7 @@ Supported ways to configure and modify tuf-on-ci workflows:
 ### Custom GitHub token
 
 tuf-on-ci uses GITHUB_TOKEN by default but supports using a custom fine-grained Github
-token. The token needs following permissions:
+token. The token needs following repository permissions:
 * `Contents: write` to create online signing commits, and to create targets metadata
   change commits in signing event
 * `Issues: write` to create comments in signing events
@@ -116,3 +116,7 @@ token. The token needs following permissions:
 Using a custom token allows keeping the default GITHUB_TOKEN with stricter permissions.
 To use a custom token, define a _repository secret_ `TUF_ON_CI_TOKEN` with a fine grained
 token as the secrets value. No workflow changes are needed.
+
+Note that all automated comments in signing event issues will be seemingly made by the
+account that created the custom token: Creating the token on a "bot" account is sensible
+for this reason.

--- a/docs/REPOSITORY-MAINTENANCE.md
+++ b/docs/REPOSITORY-MAINTENANCE.md
@@ -101,22 +101,23 @@ Supported ways to configure and modify tuf-on-ci workflows:
   see [ONLINE-SIGNING-SETUP.md] for details
 * A custom GitHub token can be optionally configured with _Repository Secret_
   `TUF_ON_CI_TOKEN`, see details below
-* The `publish` workflow is can be customized to publish to a destination that is not
+* The `publish` workflow can be customized to publish to a destination that is not
   the default GitHub Pages
 
 ### Custom GitHub token
 
 tuf-on-ci uses GITHUB_TOKEN by default but supports using a custom fine-grained Github
-token. The token needs following repository permissions:
+token. This allows the GitHub organization to limit the default GITHUB_TOKEN permissions
+(in practice this means other workflows in the repository can operate with this lower
+permission default token while tuf-on-ci workflows still have higher permissions).
+
+The custom token needs the following repository permissions:
 * `Contents: write` to create online signing commits, and to create targets metadata
   change commits in signing event
 * `Issues: write` to create comments in signing events
 * `Actions: write` to dispatch other workflows when needed
 
-Using a custom token allows keeping the default GITHUB_TOKEN with stricter permissions.
 To use a custom token, define a _repository secret_ `TUF_ON_CI_TOKEN` with a fine grained
-token as the secrets value. No workflow changes are needed.
-
-Note that all automated comments in signing event issues will be seemingly made by the
-account that created the custom token: Creating the token on a "bot" account is sensible
-for this reason.
+token as the secrets value. No workflow changes are needed. Note that all automated comments
+in signing event issues will be seemingly made by the account that created the custom
+token: Creating the token on a "bot" account is sensible for this reason.

--- a/docs/REPOSITORY-MAINTENANCE.md
+++ b/docs/REPOSITORY-MAINTENANCE.md
@@ -98,7 +98,7 @@ upgrade mechanism is to copy the modified workflows from tuf-on-ci-template.
 
 Supported ways to configure and modify tuf-on-ci workflows:
 * online signing is configured using signing method specific _Repository Variables_,
-  see [ONLINE-SIGNING-SETUP.md] for details
+  see [ONLINE-SIGNING-SETUP.md](ONLINE-SIGNING-SETUP.md) for details
 * A custom GitHub token can be optionally configured with _Repository Secret_
   `TUF_ON_CI_TOKEN`, see details below
 * The `publish` workflow can be customized to publish to a destination that is not

--- a/docs/REPOSITORY-MAINTENANCE.md
+++ b/docs/REPOSITORY-MAINTENANCE.md
@@ -87,3 +87,32 @@ use.
 After this the delegating role signers (in this case root signers) accept
 the new key by signing the delegating metadata version.
 </details>
+
+## Configuration and modifying workflows
+
+tuf-on-ci workflows (with the exception of `publish`) are written in a way to minimize
+need to modify the workflows: It may be useful to consider the workflows part of the
+tuf-on-ci application. The intention with this is to make workflow upgrades easier:
+tuf-on-ci release notes will mention when workflows change and typically the suggested
+upgrade mechanism is to copy the modified workflows from tuf-on-ci-template.
+
+Supported ways to configure and modify tuf-on-ci workflows:
+* online signing is configured using signing method specific _Repository Variables_,
+  see [ONLINE-SIGNING-SETUP.md] for details
+* A custom GitHub token can be optionally configured with _Repository Secret_
+  `TUF_ON_CI_TOKEN`, see details below
+* The `publish` workflow is can be customized to publish to a destination that is not
+  the default GitHub Pages
+
+### Custom GitHub token
+
+tuf-on-ci uses GITHUB_TOKEN by default but supports using a custom fine-grained Github
+token. The token needs following permissions:
+* `Contents: write` to create online signing commits, and to create targets metadata
+  change commits in signing event
+* `Issues: write` to create comments in signing events
+* `Actions: write` to dispatch other workflows when needed
+
+Using a custom token allows keeping the default GITHUB_TOKEN with stricter permissions.
+To use a custom token, define a _repository secret_ `TUF_ON_CI_TOKEN` with a fine grained
+token as the secrets value. No workflow changes are needed.

--- a/repo/pyproject.toml
+++ b/repo/pyproject.toml
@@ -23,6 +23,7 @@ tuf-on-ci-build-repository = "tuf_on_ci:build_repository"
 tuf-on-ci-create-signing-events = "tuf_on_ci:create_signing_events"
 tuf-on-ci-online-sign = "tuf_on_ci:online_sign"
 tuf-on-ci-status = "tuf_on_ci:status"
+tuf-on-ci-update-targets = "tuf_on_ci:update_targets"
 
 [[tool.mypy.overrides]]
 module = [

--- a/repo/tuf_on_ci/__init__.py
+++ b/repo/tuf_on_ci/__init__.py
@@ -3,4 +3,10 @@ from tuf_on_ci.create_signing_events import create_signing_events
 from tuf_on_ci.online_sign import online_sign
 from tuf_on_ci.signing_event import status, update_targets
 
-__all__ = ["build_repository", "create_signing_events", "online_sign", "status", "update_targets"]
+__all__ = [
+    "build_repository",
+    "create_signing_events",
+    "online_sign",
+    "status",
+    "update_targets",
+]

--- a/repo/tuf_on_ci/__init__.py
+++ b/repo/tuf_on_ci/__init__.py
@@ -1,6 +1,6 @@
 from tuf_on_ci.build_repository import build_repository
 from tuf_on_ci.create_signing_events import create_signing_events
 from tuf_on_ci.online_sign import online_sign
-from tuf_on_ci.status import status
+from tuf_on_ci.signing_event import status, update_targets
 
-__all__ = ["build_repository", "create_signing_events", "online_sign", "status"]
+__all__ = ["build_repository", "create_signing_events", "online_sign", "status", "update_targets"]

--- a/repo/tuf_on_ci/signing_event.py
+++ b/repo/tuf_on_ci/signing_event.py
@@ -150,7 +150,79 @@ def _role_status(repo: CIRepository, role: str, event_name) -> bool:
 @click.command()  # type: ignore[arg-type]
 @click.option("-v", "--verbose", count=True, default=0)
 @click.option("--push/--no-push", default=True)
-def status(verbose: int, push: bool) -> None:
+def update_targets(verbose: int, push: bool) -> None:
+    """Tool to update targets metadata based on artifact changes
+
+    Compares artifacts to known good state. For all changed artifacts, makes
+    corresponding changes to targets metadata and commits those changes to git.
+    The targets metadata will be unsigned at this point.
+
+    Return value is 0 if any targets metadata was updated.
+    """
+    logging.basicConfig(level=logging.WARNING - verbose * 10)
+
+    event_name = _git(["branch", "--show-current"]).stdout.strip()
+    head = _git(["rev-parse", "HEAD"]).stdout.strip()
+
+    if not os.path.exists("metadata/root.json"):
+        sys.exit(1)
+
+    # Find the known-good commit
+    merge_base = _git(["merge-base", "origin/main", "HEAD"]).stdout.strip()
+    if head == merge_base:
+        click.echo("This signing event contains no changes yet")
+        sys.exit(1)
+
+    with TemporaryDirectory() as known_good_dir:
+        _git(["clone", "--quiet", ".", known_good_dir])
+        _git(["-C", known_good_dir, "checkout", "--quiet", merge_base])
+
+        good_metadata = os.path.join(known_good_dir, "metadata")
+        good_targets = os.path.join(known_good_dir, "targets")
+
+        # Find artifacts that have changed in this signing event
+        # Update targets metadata for those artifacts if needed.
+        repo = CIRepository("metadata", good_metadata)
+
+        roles = _find_changed_target_roles(good_targets, "targets")
+
+        # Update targets metadata if necessary
+        targets_updated = False
+        for role in roles:
+            if repo.update_targets(role):
+                # metadata and artifacts were not in sync: commit new metadata
+                msg = f"Update targets metadata for role {role}"
+                _git(["commit", "-m", msg, "--", f"metadata/{role}.json"])
+                if not targets_updated:
+                    click.echo("### Metadata update based on artifact change")
+                    click.echo(
+                        f"Event [{event_name}](../compare/{event_name}) "
+                        f"(commit {head[:7]})"
+                    )
+                click.echo(f"Role `{role}` artifacts have been modified")
+                targets_updated = True
+
+    if push and targets_updated:
+        try:
+            _git(["push", "origin", event_name])
+        except subprocess.CalledProcessError as e:
+            # Figure out if this is an error caused by remote being ahead
+            # of local branch
+            msg = "Updates were rejected because the remote contains work that you do"
+            found = e.stdout.find(msg)
+            if found:
+                m = "There are changes in the signing event. Skipping metadata update"
+                print(m)
+            else:
+                print("Git output on error:", e.stdout, e.stderr)
+                raise e
+
+    sys.exit(0 if targets_updated else 1)
+
+
+@click.command()  # type: ignore[arg-type]
+@click.option("-v", "--verbose", count=True, default=0)
+def status(verbose: int) -> None:
     """Status markdown output tool"""
     logging.basicConfig(level=logging.WARNING - verbose * 10)
 
@@ -178,8 +250,6 @@ def status(verbose: int, push: bool) -> None:
         _git(["-C", known_good_dir, "checkout", "--quiet", merge_base])
 
         good_metadata = os.path.join(known_good_dir, "metadata")
-        good_targets = os.path.join(known_good_dir, "targets")
-        success = True
 
         # Compare current repository and the known good version.
         # Print status for each role, count invalid roles
@@ -188,7 +258,6 @@ def status(verbose: int, push: bool) -> None:
         # first create a list of roles with metadata or artifact changes or invites
         roles = list(
             _find_changed_roles(good_metadata, "metadata")
-            | _find_changed_target_roles(good_targets, "targets")
             | repo.state.roles_with_delegation_invites()
         )
         # reorder, toplevels first
@@ -197,31 +266,9 @@ def status(verbose: int, push: bool) -> None:
                 roles.remove(toplevel)
                 roles.insert(0, toplevel)
 
-        # Update metadata if necessary. Output the roles current status
-        updated = False
+        success = True
         for role in roles:
-            if repo.update_targets(role):
-                # metadata and artifacts are not in sync
-                msg = f"Update targets metadata for role {role}"
-                _git(["commit", "-m", msg, "--", f"metadata/{role}.json"])
-                updated = True
-
             if not _role_status(repo, role, event_name):
                 success = False
-
-    if push and updated:
-        try:
-            _git(["push", "origin", event_name])
-        except subprocess.CalledProcessError as e:
-            # Figure out if this is an error caused by remote being ahead
-            # of local branch
-            msg = "Updates were rejected because the remote contains work that you do"
-            found = e.stdout.find(msg)
-            if found:
-                m = "There are changes in the signing event. Skipping metadata update"
-                print(m)
-            else:
-                print("Git output on error:", e.stdout, e.stderr)
-                raise e
 
     sys.exit(0 if success else 1)


### PR DESCRIPTION
## Add support for custom tokens

This PR adds support for a custom GitHub token. The idea is to keep the default GitHub token as a low-permission one (so other workflows don't operate on a high permission token unnecessarily) and to add a fine grained token with higher permissions into repository secrets.

Implementation requires some workarounds to support both default and custom tokens (see dispatching discussion below) and a bit of refactoring (see python command splitting). See docs/REPOSITORY-MAINTENANCE.md changes for documentation.

This is going to require users to modify their workflows (or rather copy the workflows from tuf-on-ci-template) on upgrade as the actions now require a token argument.

### repo code changes:
* `tuf-on-ci-status` command was previously provided by the `status` module. Refactor so that there is a `signing_event` module that provides both `tuf-on-ci-status` and `tuf-on-ci-update-targets` commands
*  `tuf-on-ci-status` is now simpler and does not modify metadata: it only outputs signing event status and sets return value based on that
*  `tuf-on-ci-update-targets` modifies targets metadata to match actual artifacts (in the same way -status used to do). If no changes are required it returns 1. If metadata changes are required, it commits changes, pushes them, outputs  a message describing what was done and returns 0

### action changes
* signing-event, online-sign and create-signing-events now _require_ a token argument
* dispatch mechanisms are tweaked to allow use of custom tokens: if the token used to make a "git push" is the default token, Github will **not** trigger a push event but if a custom token does the same, an event will be triggered. This means we need to handle the two cases differently: typically by manual dispatch that is only run if token is default token 
* _signing-event_ action now either does targets metadata updates or outputs event status: 
  * first it runs `tuf-on-ci-update-targets`. If changes were done, nothing else happens (except another signing-event workflow is manually dispatched for default token case). 
  * if no changes were done by update-targets, signing-event action then runs `tuf-on-ci-status` to output signing  event status

### workflow changes

[tuf-on-ci-template draft PR](https://github.com/theupdateframework/tuf-on-ci-template/pull/13)

* always provide a token to the actions using
```
        with:
          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
```
* allow users to define TUF_ON_CI_TOKEN secret. If they don't, GITHUB_TOKEN is used (so nothing changes by default)
* exclude the online role files from online-sign push trigger paths: this prevents annoying double triggers when online-sign pushes a commit that triggers another online-sign...
