### PR TITLE
Cleanup in pyproject.toml

### DIFF
--- a/signer/pyproject.toml
+++ b/signer/pyproject.toml
@@ -2,10 +2,6 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata]
-# for git dependencies
-allow-direct-references = true
-
 [project]
 name = "tuf-on-ci-sign"
 version = "0.3.0"


### PR DESCRIPTION
git dependencies are not allowed on PyPI so I don't see us ever using them: remove the hatchling config for that.