### PR TITLE
repo/signer: Add Signed-Off-By to all commits

### DIFF
--- a/repo/tuf_on_ci/create_signing_events.py
+++ b/repo/tuf_on_ci/create_signing_events.py
@@ -53,7 +53,7 @@ def create_signing_events(verbose: int, push: bool) -> None:
         msg = f"Periodic version bump: {rolename} v{version}"
         event = f"sign/{rolename}-v{version}"
         ref = f"refs/remotes/origin/{event}" if push else f"refs/heads/{event}"
-        _git(["commit", "-m", msg, "--", f"metadata/{rolename}.json"])
+        _git(["commit", "-m", msg, "--signoff", "--", f"metadata/{rolename}.json"])
         try:
             _git(["show-ref", "--quiet", "--verify", ref])
             logging.debug("Signing event branch %s already exists", event)

--- a/repo/tuf_on_ci/online_sign.py
+++ b/repo/tuf_on_ci/online_sign.py
@@ -58,7 +58,7 @@ def online_sign(verbose: int, push: bool) -> None:
 
         click.echo(msg)
         _git(["add", "metadata/timestamp.json", "metadata/snapshot.json"])
-        _git(["commit", "-m", msg])
+        _git(["commit", "-m", msg, "--signoff"])
         if push:
             _git(["push", "origin", "HEAD"])
     else:

--- a/repo/tuf_on_ci/signing_event.py
+++ b/repo/tuf_on_ci/signing_event.py
@@ -192,7 +192,7 @@ def update_targets(verbose: int, push: bool) -> None:
             if repo.update_targets(role):
                 # metadata and artifacts were not in sync: commit new metadata
                 msg = f"Update targets metadata for role {role}"
-                _git(["commit", "-m", msg, "--", f"metadata/{role}.json"])
+                _git(["commit", "-m", msg, "--signoff", "--", f"metadata/{role}.json"])
                 updated_targets.append(f"`{role}`")
 
     if updated_targets:

--- a/signer/tuf_on_ci_sign/delegate.py
+++ b/signer/tuf_on_ci_sign/delegate.py
@@ -373,7 +373,7 @@ def delegate(verbose: int, push: bool, event_name: str, role: str | None):
             else:
                 msg = "Initial root and targets"
             git_expect(["add", "metadata/"])
-            git_expect(["commit", "-m", msg, "--", "metadata"])
+            git_expect(["commit", "-m", msg, "--signoff", "--", "metadata"])
 
             if repo.unsigned:
                 click.echo(f"Your signature is required for role(s) {repo.unsigned}.")
@@ -383,7 +383,9 @@ def delegate(verbose: int, push: bool, event_name: str, role: str | None):
                     repo.sign(rolename)
 
                 git_expect(["add", "metadata/"])
-                git_expect(["commit", "-m", f"Signed by {user_config.name}"])
+                git_expect(
+                    ["commit", "-m", f"Signed by {user_config.name}", "--signoff"]
+                )
 
             if push:
                 branch = f"{user_config.push_remote}/{event_name}"

--- a/signer/tuf_on_ci_sign/import_repo.py
+++ b/signer/tuf_on_ci_sign/import_repo.py
@@ -178,7 +178,9 @@ def import_repo(verbose: int, push: bool, event_name: str, import_file: str | No
             print(json.dumps(import_data, indent=2))
         else:
             git_expect(["add", "metadata"])
-            git_expect(["commit", "-m", f"Repo import by {user_config.name}"])
+            git_expect(
+                ["commit", "-m", f"Repo import by {user_config.name}", "--signoff"]
+            )
 
             if repo.unsigned:
                 click.echo(f"Your signature is required for role(s) {repo.unsigned}.")
@@ -188,7 +190,9 @@ def import_repo(verbose: int, push: bool, event_name: str, import_file: str | No
                     repo.sign(rolename)
 
                 git_expect(["add", "metadata/"])
-                git_expect(["commit", "-m", f"Signed by {user_config.name}"])
+                git_expect(
+                    ["commit", "-m", f"Signed by {user_config.name}", "--signoff"]
+                )
 
             if push:
                 branch = f"{user_config.push_remote}/{event_name}"

--- a/signer/tuf_on_ci_sign/sign.py
+++ b/signer/tuf_on_ci_sign/sign.py
@@ -67,7 +67,7 @@ def sign(verbose: int, push: bool, event_name: str):
 
         if changed:
             git_expect(["add", "metadata"])
-            git_expect(["commit", "-m", f"Signed by {user_config.name}"])
+            git_expect(["commit", "-m", f"Signed by {user_config.name}", "--signoff"])
             if push:
                 branch = f"{user_config.push_remote}/{event_name}"
                 msg = f"Press enter to push signature(s) to {branch}"


### PR DESCRIPTION
All commits done by signer and repository will now include Signed-Off-By. This makes DCO check happy based on tests in https://github.com/jku/yet-another-test-repo/

I didn't want to make this configurable (because it covers both repository and signer and would be a bit of a pain to manage): hopefully enabling Signed-Off-By for everyone will:
 * not be too annoying for people who don't care about signoff
 * fix the problem for orgs that require it