### PR TITLE
Add a smoke test for published repository

### DIFF
--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -4,8 +4,10 @@ description: 'Test a published TUF-on-CI repository with a client'
 inputs:
   metadata_url:
     description: 'base metadata URL the client should use'
+    default: ''
   artifact_url:
     description: 'Base artifact URL the client should use'
+    default: ''
 
 runs:
   using: "composite"
@@ -22,6 +24,19 @@ runs:
     - env:
         METADATA_URL: ${{ inputs.metadata_url }}
         ARTIFACT_URL: ${{ inputs.artifact_url }}
+        OWNER_REPO: ${{ github.repository }}
       run: |
+        OWNER=${OWNER_REPO%/*}
+        REPO=${OWNER_REPO#*/}
+
+        # guess reasonable default urls
+        if [ -z $METADATA_URL ]; then
+          METADATA_URL="https://${OWNER}.github.io/${REPO}/metadata/"
+        fi
+        if [ -z $ARTIFACT_URL ]; then
+          ARTIFACT_URL="https://${OWNER}.github.io/${REPO}/targets/"
+        fi
+
+        echo "Testing repository at metadata-url $METADATA_URL, artifact-url $ARTIFACT_URL"
         tuf-on-ci-test-client --metadata-url "$METADATA_URL" --artifact-url "$ARTIFACT_URL"
       shell: bash

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -8,6 +8,9 @@ inputs:
   artifact_url:
     description: 'Base artifact URL the client should use'
     default: ''
+  expected_artifact:
+    description: 'Optional artifact path that should be checked to exist in the repository'
+    default: ''
 
 runs:
   using: "composite"
@@ -24,6 +27,7 @@ runs:
     - env:
         METADATA_URL: ${{ inputs.metadata_url }}
         ARTIFACT_URL: ${{ inputs.artifact_url }}
+        EXPECTED_ARTIFACT: ${{ inputs.expected_artifact }}
         OWNER_REPO: ${{ github.repository }}
       run: |
         OWNER=${OWNER_REPO%/*}
@@ -37,6 +41,16 @@ runs:
           ARTIFACT_URL="https://${OWNER}.github.io/${REPO}/targets/"
         fi
 
+        # set --expected-artifact if input is used
+        if [ -z $EXPECTED_ARTIFACT ]; then
+          ARTIFACT_ARG=""
+        else
+          ARTIFACT_ARG="--expected-artifact $EXPECTED_ARTIFACT"
+        fi
+
         echo "Testing repository at metadata-url $METADATA_URL, artifact-url $ARTIFACT_URL"
-        tuf-on-ci-test-client --metadata-url "$METADATA_URL" --artifact-url "$ARTIFACT_URL"
+        tuf-on-ci-test-client \
+          --metadata-url "$METADATA_URL" \
+          --artifact-url "$ARTIFACT_URL" \
+          $ARTIFACT_ARG
       shell: bash

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -1,0 +1,27 @@
+name: 'Test TUF-on-CI repository'
+description: 'Test a published TUF-on-CI repository with a client'
+
+inputs:
+  metadata_url:
+    description: 'base metadata URL the client should use'
+  artifact_url:
+    description: 'Base artifact URL the client should use'
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
+      with:
+        python-version: "3.11"
+
+    - run: pip install $GITHUB_ACTION_PATH/../../repo/
+      shell: bash
+
+    - env:
+        METADATA_URL: ${{ inputs.metadata_url }}
+        ARTIFACT_URL: ${{ inputs.artifact_url }}
+      run: |
+        tuf-on-ci-test-client --metadata-url "$METADATA_URL" --artifact-url "$ARTIFACT_URL"
+      shell: bash

--- a/client/README.md
+++ b/client/README.md
@@ -1,8 +1,0 @@
-## TUF-on-CI Downloader client example
-
-TODO: There is currently no client code here.
-
-A standard TUF client should work with one caveat: if the TUF-on-CI repository uses
-sigstore signatures, these must be supported in the downloader client (and no tuf libraries
-currently do that by default: python-tuf and securesystemslib can be configured to do so).
-

--- a/repo/pyproject.toml
+++ b/repo/pyproject.toml
@@ -20,6 +20,7 @@ requires-python = ">=3.10"
 
 [project.scripts]
 tuf-on-ci-build-repository = "tuf_on_ci:build_repository"
+tuf-on-ci-test-client = "tuf_on_ci:client"
 tuf-on-ci-create-signing-events = "tuf_on_ci:create_signing_events"
 tuf-on-ci-online-sign = "tuf_on_ci:online_sign"
 tuf-on-ci-status = "tuf_on_ci:status"

--- a/repo/tuf_on_ci/__init__.py
+++ b/repo/tuf_on_ci/__init__.py
@@ -1,10 +1,12 @@
 from tuf_on_ci.build_repository import build_repository
+from tuf_on_ci.client import client
 from tuf_on_ci.create_signing_events import create_signing_events
 from tuf_on_ci.online_sign import online_sign
 from tuf_on_ci.signing_event import status, update_targets
 
 __all__ = [
     "build_repository",
+    "client",
     "create_signing_events",
     "online_sign",
     "status",

--- a/repo/tuf_on_ci/client.py
+++ b/repo/tuf_on_ci/client.py
@@ -1,0 +1,49 @@
+# Copyright 2012 - 2023, New York University and the TUF contributors
+# Copyright 2024 Google LLC
+
+"""Command line testing client for a tuf-on-ci repository"""
+
+import logging
+import os
+from tempfile import TemporaryDirectory, mkdtemp
+import shutil
+import click
+
+from tuf.ngclient import Updater
+
+
+# TODO:
+# * Enable support for sigstore signatures
+# * Add feature to download a specific file
+# * optionally test with cached metadata?
+
+@click.command()
+@click.option("-v", "--verbose", count=True, default=0)
+@click.option("-m", "--metadata-url", type=str, required=True)
+@click.option("-a", "--artifact-url", type=str, required=True)
+@click.option("-t", "--root", default="metadata/root_history/1.root.json", help="root metadata to populate client cache")
+@click.option("-t", "--metadata-cache", type=str, help="directory with an existing client cache that should be used")
+def client(verbose: int, metadata_url: str, artifact_url: str, root: str, metadata_cache: str | None) -> None:
+    """Test client for tuf-on-ci"""
+
+    logging.basicConfig(level=logging.WARNING - verbose * 10)
+
+    with TemporaryDirectory() as client_dir:
+        metadata_dir = os.path.join(client_dir, "metadata")
+        artifact_dir = os.path.join(client_dir, "artifacts")
+        os.mkdir(metadata_dir)
+        os.mkdir(artifact_dir)
+
+        if metadata_cache:
+            # pre-populate the client cache with given directory
+            for fname in os.listdir(metadata_cache):
+                fpath = os.path.join(metadata_cache, fname)
+                if os.path.isfile(fpath):
+                    shutil.copy(fpath, os.path.join(metadata_dir, fname))
+        else:
+            # pre-populate the client cache with just a root file
+            shutil.copy(root, os.path.join(metadata_dir, "root.json"))
+
+        # For now, just confirm we can get up-to-date top level metadata from remote
+        updater = Updater(metadata_dir, metadata_url, artifact_dir, artifact_url)
+        updater.refresh()

--- a/repo/tuf_on_ci/client.py
+++ b/repo/tuf_on_ci/client.py
@@ -5,25 +5,36 @@
 
 import logging
 import os
-from tempfile import TemporaryDirectory, mkdtemp
 import shutil
-import click
+from tempfile import TemporaryDirectory
 
+import click
 from tuf.ngclient import Updater
 
-
-# TODO:
-# * Enable support for sigstore signatures
-# * Add feature to download a specific file
-# * optionally test with cached metadata?
 
 @click.command()
 @click.option("-v", "--verbose", count=True, default=0)
 @click.option("-m", "--metadata-url", type=str, required=True)
 @click.option("-a", "--artifact-url", type=str, required=True)
-@click.option("-t", "--root", default="metadata/root_history/1.root.json", help="root metadata to populate client cache")
-@click.option("-t", "--metadata-cache", type=str, help="directory with an existing client cache that should be used")
-def client(verbose: int, metadata_url: str, artifact_url: str, root: str, metadata_cache: str | None) -> None:
+@click.option(
+    "-t",
+    "--root",
+    default="metadata/root_history/1.root.json",
+    help="root metadata to populate client cache",
+)
+@click.option(
+    "-t",
+    "--metadata-cache",
+    type=str,
+    help="directory with an existing client cache that should be used",
+)
+def client(
+    verbose: int,
+    metadata_url: str,
+    artifact_url: str,
+    root: str,
+    metadata_cache: str | None,
+) -> None:
     """Test client for tuf-on-ci"""
 
     logging.basicConfig(level=logging.WARNING - verbose * 10)

--- a/repo/tuf_on_ci/client.py
+++ b/repo/tuf_on_ci/client.py
@@ -18,6 +18,7 @@ from tuf.ngclient import Updater
 @click.option("-v", "--verbose", count=True, default=0)
 @click.option("-m", "--metadata-url", type=str, required=True)
 @click.option("-a", "--artifact-url", type=str, required=True)
+@click.option("-e", "--expected-artifact", type=str)
 @click.option(
     "-c",
     "--metadata-cache",
@@ -28,6 +29,7 @@ def client(
     verbose: int,
     metadata_url: str,
     artifact_url: str,
+    expected_artifact: str | None,
     metadata_cache: str | None,
 ) -> None:
     """Test client for tuf-on-ci
@@ -65,3 +67,12 @@ def client(
             if not cmp(f"metadata/{f}", os.path.join(metadata_dir, f), shallow=False):
                 sys.exit(f"Client metadata freshness: {f} failed")
         print("Client metadata freshness: OK")
+
+        if expected_artifact:
+            # Test expected artifact existence
+            tinfo = updater.get_targetinfo(expected_artifact)
+            if not tinfo:
+                sys.exit("Expected artifact '{expected_artifact}' not found")
+
+            updater.download_target(tinfo)
+            print(f"Expected artifact '{expected_artifact}': OK")


### PR DESCRIPTION
This adds an action that runs a basic client against the repository  

The action could be used in
* cron workflow
* publish workflow

Fixes #38 (at least parts of it)
