### PR TITLE
feature: Add integrated issue handling

### DIFF
--- a/actions/create-signing-events/action.yml
+++ b/actions/create-signing-events/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         python-version: "3.11"
 
-    - run: pip install $GITHUB_ACTION_PATH/../../repo/
+    - run: pip --quiet install $GITHUB_ACTION_PATH/../../repo/
       shell: bash
 
     - name: Create signing event branches for expiring roles

--- a/actions/online-sign/action.yml
+++ b/actions/online-sign/action.yml
@@ -49,7 +49,7 @@ runs:
       with:
         python-version: "3.11"
 
-    - run: pip install $GITHUB_ACTION_PATH/../../repo/
+    - run: pip --quiet install $GITHUB_ACTION_PATH/../../repo/
       shell: bash
 
     - id: online-sign

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -33,7 +33,7 @@ runs:
       with:
         python-version: "3.11"
 
-    - run: pip install $GITHUB_ACTION_PATH/../../repo/
+    - run: pip --quiet install $GITHUB_ACTION_PATH/../../repo/
       shell: bash
 
     - id: update_targets

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -21,7 +21,7 @@ runs:
       with:
         python-version: "3.11"
 
-    - run: pip install $GITHUB_ACTION_PATH/../../repo/
+    - run: pip --quiet install $GITHUB_ACTION_PATH/../../repo/
       shell: bash
 
     - env:

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -16,6 +16,8 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        ref: "publish"
 
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:

--- a/actions/update-issue/action.yml
+++ b/actions/update-issue/action.yml
@@ -3,7 +3,7 @@ description: 'Create, close or add a comment in a GitHub issue for a workflow fa
 # * This action will open an issue per workflow if that workflow fails.
 # * If an issue is open for that workflow already, the action will add a comment.
 # * If an issue is open and the workflow succeeds, the action will close the issue.
-# * The issue is identified using a label that is the workflow filename.
+# * The issue is identified using a label that is the workflow name.
 # * Required permissions:
 #     issues: write
 
@@ -30,12 +30,11 @@ runs:
 
           success = (process.env.SUCCESS == "true")
 
-          // Find issue labeled with the forkflow filename
-          const label = path.basename(context.payload.workflow)
+          // Find issue labeled with the forkflow name
           const issues = await github.rest.issues.listForRepo({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            labels: [label],
+            labels: [context.workflow],
           })
           if (issues.data.length == 0) {
             issue_number = 0
@@ -52,21 +51,14 @@ runs:
           const run_url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
           if (success) {
             body = `### Workflow run succeeded for ${context.workflow}.\n` +
-                   `Succesful run: ${run_url}\n\n` +
+                   `Successful run: ${run_url}\n\n` +
                    `Closing issue based on this success.`
           } else if (issue_number){
             body = `### Workflow run failed for ${context.workflow}.\n` +
                    `Failed run: ${run_url}\n\n`
           } else {
-            retry_line = ""
-            if (label == "online-sign.yml" ||
-                label == "create-signing-events.yml" ||
-                label == "test-repository.yml") {
-              retry_line = "* This workflow will be retried automatically (by default in 6 hours)\n"
-            }
             body = `### Workflow run failed for ${context.workflow}.\n` +
                    `Failed run: ${run_url}\n\n` +
-                   retry_line +
                    "* Maintainers can re-run the failing job manually\n" +
                    "* This issue will be automatically closed if a later run succeeds"
           }
@@ -78,7 +70,7 @@ runs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `Failure in ${context.workflow}`,
-              labels: [label],
+              labels: [context.workflow],
               body: body,
             })
           }

--- a/actions/update-issue/action.yml
+++ b/actions/update-issue/action.yml
@@ -51,13 +51,24 @@ runs:
           // Build comment body
           const run_url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
           if (success) {
-            body = `### Workflow run succeeded for '${context.workflow}'.\n` +
+            body = `### Workflow run succeeded for ${context.workflow}.\n` +
                    `Succesful run: ${run_url}\n\n` +
                    `Closing issue based on this success.`
+          } else if (issue_number){
+            body = `### Workflow run failed for ${context.workflow}.\n` +
+                   `Failed run: ${run_url}\n\n`
           } else {
-            body = `### Workflow run failed for '${context.workflow}'.\n` +
+            retry_line = ""
+            if (label == "online-sign.yml" ||
+                label == "create-signing-events.yml" ||
+                label == "test-repository.yml") {
+              retry_line = "* This workflow will be retried automatically (by default in 6 hours)\n"
+            }
+            body = `### Workflow run failed for ${context.workflow}.\n` +
                    `Failed run: ${run_url}\n\n` +
-                   `This issue will be automatically closed if a later run succeeds`
+                   retry_line +
+                   "* Maintainers can re-run the failing job manually\n" +
+                   "* This issue will be automatically closed if a later run succeeds"
           }
 
           // open, comment on, and close issue as needed

--- a/actions/update-issue/action.yml
+++ b/actions/update-issue/action.yml
@@ -1,0 +1,91 @@
+name: 'Update TUF-on-CI issue'
+description: 'Create, close or add a comment in a GitHub issue for a workflow failure'
+# * This action will open an issue per workflow if that workflow fails.
+# * If an issue is open for that workflow already, the action will add a comment.
+# * If an issue is open and the workflow succeeds, the action will close the issue.
+# * The issue is identified using a label that is the workflow filename.
+# * Required permissions:
+#     issues: write
+
+inputs:
+  token:
+    description: 'GitHub token'
+    required: true
+
+  success:
+    description: '"true" if workflow is succeeding'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Update issue
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      env:
+        SUCCESS: ${{ inputs.success }}
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          var path = require("path")
+
+          success = (process.env.SUCCESS == "true")
+
+          // Find issue labeled with the forkflow filename
+          const label = path.basename(context.payload.workflow)
+          const issues = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: [label],
+          })
+          if (issues.data.length == 0) {
+            issue_number = 0
+          } else {
+            issue_number = issues.data[0].number
+          }
+
+          if (success && !issue_number) {
+              console.log("update-issue: Nothing to do (success, no issue open)")
+              return
+          }
+
+          // Build comment body
+          const run_url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+          if (success) {
+            body = `### Workflow run succeeded for '${context.workflow}'.\n` +
+                   `Succesful run: ${run_url}\n\n` +
+                   `Closing issue based on this success.`
+          } else {
+            body = `### Workflow run failed for '${context.workflow}'.\n` +
+                   `Failed run: ${run_url}\n\n` +
+                   `This issue will be automatically closed if a later run succeeds`
+          }
+
+          // open, comment on, and close issue as needed
+          if (!success && !issue_number) {
+            console.log("update-issue: Opening a new issue on failure")
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Failure in ${context.workflow}`,
+              labels: [label],
+              body: body,
+            })
+          }
+          if (issue_number) {
+            console.log(`update-issue: Adding a comment (issue: ${issue_number})`)
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: body,
+            })
+          }
+          if (success) {
+            console.log(`update-issue: Closing issue on success (issue: ${issue_number})`)
+            await github.rest.issues.update({
+              issue_number: issue_number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "closed",
+            })
+          }

--- a/actions/upload-repository/action.yml
+++ b/actions/upload-repository/action.yml
@@ -30,7 +30,7 @@ runs:
       with:
         python-version: "3.11"
 
-    - run: pip install $GITHUB_ACTION_PATH/../../repo/
+    - run: pip --quiet install $GITHUB_ACTION_PATH/../../repo/
       shell: bash
 
     - id: build-repository

--- a/signer/tuf_on_ci_sign/_signer_repository.py
+++ b/signer/tuf_on_ci_sign/_signer_repository.py
@@ -397,18 +397,18 @@ class SignerRepository(Repository):
             root.add_key(online_config.key, "snapshot")
 
             # set online role periods
-            timestamp.unrecognized_fields[
-                "x-tuf-on-ci-expiry-period"
-            ] = online_config.timestamp_expiry
-            timestamp.unrecognized_fields[
-                "x-tuf-on-ci-signing-period"
-            ] = online_config.timestamp_signing
-            snapshot.unrecognized_fields[
-                "x-tuf-on-ci-expiry-period"
-            ] = online_config.snapshot_expiry
-            snapshot.unrecognized_fields[
-                "x-tuf-on-ci-signing-period"
-            ] = online_config.snapshot_signing
+            timestamp.unrecognized_fields["x-tuf-on-ci-expiry-period"] = (
+                online_config.timestamp_expiry
+            )
+            timestamp.unrecognized_fields["x-tuf-on-ci-signing-period"] = (
+                online_config.timestamp_signing
+            )
+            snapshot.unrecognized_fields["x-tuf-on-ci-expiry-period"] = (
+                online_config.snapshot_expiry
+            )
+            snapshot.unrecognized_fields["x-tuf-on-ci-signing-period"] = (
+                online_config.snapshot_signing
+            )
 
     def get_role_config(self, rolename: str) -> OfflineConfig | None:
         """Read configuration for delegation and role from metadata"""
@@ -546,12 +546,12 @@ class SignerRepository(Repository):
             if expiry == config.expiry_period and signing == config.signing_period:
                 raise AbortEdit(f"No changes to {rolename}")
 
-            signed.unrecognized_fields[
-                "x-tuf-on-ci-expiry-period"
-            ] = config.expiry_period
-            signed.unrecognized_fields[
-                "x-tuf-on-ci-signing-period"
-            ] = config.signing_period
+            signed.unrecognized_fields["x-tuf-on-ci-expiry-period"] = (
+                config.expiry_period
+            )
+            signed.unrecognized_fields["x-tuf-on-ci-signing-period"] = (
+                config.signing_period
+            )
 
         state_file_path = os.path.join(self._dir, ".signing-event-state")
         if self._invites:


### PR DESCRIPTION
Open and close issues based on workflow successes:
* If a TUF-on-CI workflow fails and issue does not exist, file an issue
* If issue for the workflow exists, add a comment
* If a TUF-on-CI workflow succeeds and issue exists for workflow, close issue


Some notes:
* I've kept this spartan on purpose: we may want some configurability but I'd rather do that based on actual user feedback
* Companion template PR: https://github.com/theupdateframework/tuf-on-ci-template/pull/17-- please review that one as part of this PR review (leave comments in either one)
* example run: https://github.com/jku/tuf-on-ci-sigstore-test/issues/20
* I'm not happy about how much this complicates the workflows but I don't see better alternatives, see https://docs.google.com/document/d/1syzgpkOFbo3npLLIVnuKEFUZHVR3B92Xo_TO2XQ99BY/edit?usp=sharing  for some details on this
* typical error in e.g. online-signing  would lead to 1 issue where a new comment is made 4 times per day as long as the signing keeps failing
* The intent is that users (like root-signing-staging) can add a call to their own reusable test workflow into test.yml: this will be covered by the issue handling

Fixes #168