### PR TITLE
Use PRs instead of issues for signing events

### DIFF
--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -93,16 +93,16 @@ runs:
           }
 
           message = fs.readFileSync('./status-output').toString()
+          summary = "Signing event in progress"
+          should_be_draft = true
           if (process.env.STATUS == 'success') {
             message += "### Signing event is successful\n\n"
             message += "Threshold of signatures has been reached: this signing event can be reviewed and merged."
             summary = "Signing event is successful"
             should_be_draft = false
-          } else {
-            summary = "Signing event in progress"
-            should_be_draft = true
           }
 
+          // Pull request numbers are also valid issue numbers
           github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -99,13 +99,11 @@ runs:
             message += "### Signing event is successful\n\n"
             message += "Threshold of signatures has been reached: this signing event can be reviewed and merged."
             summary = "Signing event is successful"
-            draft = false
+            should_be_draft = false
           } else {
             summary = "Signing event in progress"
-            draft = true
+            should_be_draft = true
           }
-
-          // TODO set draft state here: The rest api does not support that
 
           github.rest.issues.createComment({
             owner: context.repo.owner,
@@ -113,6 +111,32 @@ runs:
             issue_number: pr,
             body: message,
           })
+
+          // Following pile of GraphQL is here because draft state cannot
+          // be modified through rest API at all!
+
+          // First get the PR "Id" and current draft state...
+          response = await github.graphql(`query {
+            repository(owner: "${context.repo.owner}", name: "${context.repo.repo}") {
+              pullRequest(number: ${pr}) { id, isDraft }
+            }
+          }`)
+          pr_id = response.repository.pullRequest.id
+          is_draft = response.repository.pullRequest.isDraft
+          // Then modify PR if needed
+          if (should_be_draft && !is_draft) {
+            await github.graphql(`mutation SetPullRequestDraft {
+              convertPullRequestToDraft(input: {pullRequestId: "${pr_id}"}) {
+                pullRequest { isDraft }
+              }
+            }`)
+          } else if (!should_be_draft && is_draft) {
+            await github.graphql(`mutation SetPullRequestReady {
+              markPullRequestReadyForReview(input: {pullRequestId: "${pr_id}"}) {
+                pullRequest { isDraft }
+              }
+            }`)
+          }
 
           await core.summary.addHeading(summary).write()
 

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -59,7 +59,7 @@ runs:
         cat status-output >> "$GITHUB_STEP_SUMMARY"
       shell: bash
 
-    - id: file-issue
+    - id: update-pr
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       env:
         STATUS: ${{ steps.status.outputs.status }}
@@ -70,46 +70,47 @@ runs:
           message = fs.readFileSync('./status-output').toString()
           summary = ''
 
-          issue = 0
+          pr = 0
           const repo = context.repo.owner + "/" + context.repo.repo
-          const issues = await github.rest.issues.listForRepo({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            labels: [process.env.GITHUB_REF_NAME],
+          const prs = await github.rest.search.issuesAndPullRequests({
+            q: "label:" + process.env.GITHUB_REF_NAME + "+state:open+type:pr+repo:" + repo,
           })
-          if (issues.data.length > 1) {
-            core.setFailed("Found more than one issue with same label")
-          } else if (issues.data.length == 0) {
-            const response = await github.rest.issues.create({
+          if (prs.data.total_count > 1) {
+            core.setFailed("Found more than one pull request with same label")
+          } else if (prs.data.total_count == 0) {
+            const response = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Signing event: " + process.env.GITHUB_REF_NAME,
               body: "Processing signing event " + process.env.GITHUB_REF_NAME + ", please wait.",
               labels: [process.env.GITHUB_REF_NAME],
+              draft: true,
+              head: process.env.GITHUB_REF_NAME,
+              base: "main",
             })
-            issue = response.data.number
-            console.log("Created issue #" + issue)
+            pr = response.data.number
+            console.log("Created pull request #" + pr)
           } else {
-            issue = issues.data[0].number
-            console.log("Found existing issue #" + issue)
+            pr = prs.data.items[0].number
+            console.log("Found existing pull request #" + pr)
           }
 
           if (process.env.STATUS == 'success') {
-            pr_url = new URL("https://github.com/" + repo + "/compare/main..." + process.env.GITHUB_REF_NAME)
-            pr_url.searchParams.set("expand", "1")
-            pr_url.searchParams.set("title", "Signing event " + process.env.GITHUB_REF_NAME)
-            pr_url.searchParams.set("body", "Signing event " + process.env.GITHUB_REF_NAME + " is successful and ready to merge.\n\nCloses #" + issue + ".")
             message += "### Signing event is successful\n\n"
-            message += "Threshold of signatures has been reached. A [pull request](" + pr_url + ") can be opened."
+            message += "Threshold of signatures has been reached: this signing event can be reviewed and merged."
             summary = "Signing event is successful"
+            draft = false
           } else {
             summary = "Signing event in progress"
+            draft = true
           }
 
+          // TODO set draft state here: The rest api does not support that
+
           github.rest.issues.createComment({
-            issue_number: issue,
             owner: context.repo.owner,
             repo: context.repo.repo,
+            issue_number: pr,
             body: message,
           })
 

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -67,15 +67,12 @@ runs:
         github-token: ${{ inputs.token }}
         script: |
           const fs = require('fs')
-          message = fs.readFileSync('./status-output').toString()
-          title = "Signing event: " + process.env.GITHUB_REF_NAME
-          summary = ''
-
-          pr = 0
-          const repo = context.repo.owner + "/" + context.repo.repo
+          const title = `Signing event: ${process.env.GITHUB_REF_NAME}`
+          const repo = `${context.repo.owner}/${context.repo.repo}`
           const prs = await github.rest.search.issuesAndPullRequests({
             q: `in:title+"${title}"+state:open+type:pr+repo:${repo}`
           })
+
           if (prs.data.total_count > 1) {
             core.setFailed("Found more than one open pull request with same title")
           } else if (prs.data.total_count == 0) {
@@ -83,18 +80,19 @@ runs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: title,
-              body: "Processing signing event " + process.env.GITHUB_REF_NAME + ", please wait.",
+              body: `Processing signing event ${process.env.GITHUB_REF_NAME}, please wait.`,
               draft: true,
               head: process.env.GITHUB_REF_NAME,
               base: "main",
             })
             pr = response.data.number
-            console.log("Created pull request #" + pr)
+            console.log(`Created pull request #${pr}`)
           } else {
             pr = prs.data.items[0].number
-            console.log("Found existing pull request #" + pr)
+            console.log(`Found existing pull request #${pr}`)
           }
 
+          message = fs.readFileSync('./status-output').toString()
           if (process.env.STATUS == 'success') {
             message += "### Signing event is successful\n\n"
             message += "Threshold of signatures has been reached: this signing event can be reviewed and merged."

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -68,22 +68,22 @@ runs:
         script: |
           const fs = require('fs')
           message = fs.readFileSync('./status-output').toString()
+          title = "Signing event: " + process.env.GITHUB_REF_NAME
           summary = ''
 
           pr = 0
           const repo = context.repo.owner + "/" + context.repo.repo
           const prs = await github.rest.search.issuesAndPullRequests({
-            q: "label:" + process.env.GITHUB_REF_NAME + "+state:open+type:pr+repo:" + repo,
+            q: `in:title+"${title}"+state:open+type:pr+repo:${repo}`
           })
           if (prs.data.total_count > 1) {
-            core.setFailed("Found more than one pull request with same label")
+            core.setFailed("Found more than one open pull request with same title")
           } else if (prs.data.total_count == 0) {
             const response = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Signing event: " + process.env.GITHUB_REF_NAME,
+              title: title,
               body: "Processing signing event " + process.env.GITHUB_REF_NAME + ", please wait.",
-              labels: [process.env.GITHUB_REF_NAME],
               draft: true,
               head: process.env.GITHUB_REF_NAME,
               base: "main",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+**NOTE:** please see upgrade instructions below.
+
+**Changes**
+
+* Signing events now happen in GitHub pull requests
+
+**Upgrade instructions**
+
+* As usual we recommend copying your workflows from
+  https://github.com/theupdateframework/tuf-on-ci-template/.
+  * signing event action no longer needs `issues: write` permission
+    but instead requires `pull-requests: write`
+* Custom token users need to create a new token with an additional
+  permission `Pull requests: write`
+
+
 ## v0.5.0
 
 **NOTE:** Do not accept a dependabot upgrade, please see upgrade

--- a/docs/REPOSITORY-MAINTENANCE.md
+++ b/docs/REPOSITORY-MAINTENANCE.md
@@ -34,8 +34,8 @@ Roles are modified with `tuf-on-ci-delegate <event> <role>`.
   event does not exist yet, it will be created as a result.
 * The tool will prompt for new signers and other details, and then prompt to push changes
   to the repository.
-* The push triggers creation of a signing event GitHub issue. The repository will report the
-  status of the signing event and will notify signers with advice.
+* The push triggers creation of a signing event pull request. The repository will report the
+  status of the signing event in the pull request and will notify signers there.
 
 ### Examples
 
@@ -76,9 +76,10 @@ which in the above example is `sign/add-fakueuser-2`.
 
 The repository automation runs the [signing
 automation](https://github.com/theupdateframework/tuf-on-ci-template/blob/main/.github/workflows/signing-event.yml)
-that creates issues with the current signing state and tags each
-signer on what's expected to do. This always provides a clear state of
-the situation.
+that creates PRs with comments documenting current signing event state
+and tags each signer. These comments (along with the PR commits) should
+provide signers with a clear view of what is happening in the signing
+event.
 
 To accept the invitation and become a signer, the invitee runs
 `tuf-on-ci-sign <event-name>` and provides information on what key to
@@ -114,10 +115,11 @@ permission default token while tuf-on-ci workflows still have higher permissions
 The custom token needs the following repository permissions:
 * `Contents: write` to create online signing commits, and to create targets metadata
   change commits in signing event
-* `Issues: write` to create comments in signing events
+* `Issues: write` to create issues on workflow failures
+* `Pull requests: write` to create and modify signing event pull requests
 * `Actions: write` to dispatch other workflows when needed
 
 To use a custom token, define a _repository secret_ `TUF_ON_CI_TOKEN` with a fine grained
 token as the secrets value. No workflow changes are needed. Note that all automated comments
-in signing event issues will be seemingly made by the account that created the custom
+in signing event pull requests will be seemingly made by the account that created the custom
 token: Creating the token on a "bot" account is sensible for this reason.

--- a/docs/SIGNER-MANUAL.md
+++ b/docs/SIGNER-MANUAL.md
@@ -15,8 +15,8 @@ metadata of a _role_ by signing that role's metadata with their personal signing
 (e.g. a Yubikey).
 
 _Signing event_: Collaboration of one or more signers to produce and sign a new version of 
-a role's metadata. A signing event happens in a GitHub issue and there is an associated git
-branch where the changes and signatures are stored. Signing event names start with "sign/".
+a role's metadata. A signing event happens in a GitHub pull request. Signing event names
+start with "sign/".
 
 _Role_: A role manages a set of artifacts and (optionally) a set of delegations to other
 roles. A role has a set of _signers_ (defined by the delegating role): their signatures
@@ -27,20 +27,20 @@ role (delegated by root). The targets role can further delegate to other roles.
 ## Usage
 
 Metadata is signed in a _signing event_. The signing event process is:
-* A signing event GitHub issue gets created by the repository. This happens as a
+* A signing event pull request gets created by the repository. This happens as a
   response to either a timed event (like an expiry date approaching) or as a response to
   artifact changes. Either way, the signing event contains new metadata versions that
   need to be signed before they are considered valid.
 * The signing event directs _signers_ to sign the changes using `tuf-on-ci-sign`. By
   signing they confirm that the proposed changes are correct. The local signing tool
-  updates the remote signing event branch with the signatures.
+  makes a commit with the signature pushes the commit to the remote signing event branch.
   * If a signer does not have push permissions for the GitHub repository, their signature
-    is added to the signing event via PR from their fork.
+    is added to the signing event via PR from their fork to the signing event branch.
 * Finally, a Pull Request to merge the signing event into main is created.
 
-Throughout the process, the repository updates the signing event issue with status
-reports. These reports in the  signing event issue function as a notification mechanism
-but *signers should only ever fully trust their local signing tool*.
+Throughout the process, the repository updates the signing event pull request with status
+reports. These reports in the signing event pull request function as a notification
+mechanism but *signers should only ever fully trust their local signing tool*.
 
 The signing tool works in the repository (git clone) directory -- note that
 fetching, pushing or switching branches is not necessary: the tool will always use an
@@ -49,7 +49,7 @@ automatically pushed to the signing event branch.
 
 ### Accepting an invitation 
 
-When a signing event GitHub issue invites to become a signer:
+When a signing event pull request invites to become a signer:
 ```shell
 $ tuf-on-ci-sign <event>
 ```
@@ -60,7 +60,7 @@ $ tuf-on-ci-sign <event>
 
 ### Signing a change
 
-When a signing event GitHub issue instructs to sign a change:
+When a signing event pull request instructs to sign a change:
 ```shell
 $ tuf-on-ci-sign <event>
 ```
@@ -74,8 +74,8 @@ $ tuf-on-ci-sign <event>
 
 Artifacts are stored in git (in the `targets/` directory) and are modified using normal
 git tools: the signing tool is not used. Artifact modification commits should get pushed to a
-branch on the repository: this creates a signing event for the artifact change allowing signers
-to sign that change.
+branch on the repository (with a branch name starting with "sign/"): this creates a signing
+event for the artifact change allowing signers to sign that change.
 
 The role where the artifact belongs to is chosen with pathname: 
 * files in the targets directory are artifacts managed by top level role "targets" 

--- a/repo/tuf_on_ci/signing_event.py
+++ b/repo/tuf_on_ci/signing_event.py
@@ -200,7 +200,8 @@ def update_targets(verbose: int, push: bool) -> None:
         click.echo(f"Event [{event_name}](../compare/{event_name}) (commit {head[:7]})")
 
         role_str = ", ".join(updated_targets)
-        click.echo(f"Updating metadata for role(s) {role_str}.")
+        click.echo(f"Committed metadata changes for role(s) {role_str}.")
+        click.echo("Updating signing event state, please wait.")
 
     if push and updated_targets:
         try:

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,7 @@ TUF-on-CI is implemented on top of a CI system, git and includes quite a bit of
 user interaction (through both the CI system and the signing tools). This makes
 testing tricky. These tests are an attempt at defining a set of functionality that
 can be tested without
-* Github issues being created
+* Github pull requests being created
 * git branches modified on github.com
 * sigstore or Google Cloud signing for online keys
 * a user signing with a Yubikey


### PR DESCRIPTION
Pull requests make more sense for the signing event:
* Since there is a branch associated with the signing event, PR matches that better than issue
* The UI is better as the commits are now visible in between the comments

The issue of course is that a signing event can spend a while in a state when it's not ready for merging or even review. This is manageable because:
* we can manage the draft state: the PR is a draft until the signing event is ready
* The check is now visible and useful: it's very clear if the signing event is "green" or not

The main annoyance in this PR is the use of GraphQL to modify draft state. I decided to do that instead of the other options listed in the linked issue discussion. The best alternative would be to rely more on bash and to use `gh` tool as an API. I think I still prefer js to bash for this...

Fixes #78
Example PR: jku/tuf-on-ci-sigstore-test#31