### PR TITLE
Lint improvements

### DIFF
--- a/repo/pyproject.toml
+++ b/repo/pyproject.toml
@@ -33,7 +33,20 @@ module = [
 ]
 ignore_missing_imports = "True"
 
-[tool.ruff]
-# pycodestyle errors(E) and Pyflakes (F) are enabled by default.
-# Also enable isort (I) and pep8-naming (N) .
-select = ["E", "F", "I", "N"]
+[tool.ruff.lint]
+select = [
+  "B",   # flake8-bugbear
+  "BLE", # flake8-blind-except
+  "C4",  # flake8-comprehensions
+  "E",   # pycodestyle errors
+  "F",   # pyflakes
+  "I",   # isort
+  "N",   # pep8-naming
+  "S",   # flake8-bandit
+  "UP",  # pyupgrade
+  "W",   # pycodestyle warnings
+]
+ignore = [
+  "S101", # Use of `assert` detected
+  "S603", # `subprocess` call: check for execution of untrusted input
+]

--- a/repo/pyproject.toml
+++ b/repo/pyproject.toml
@@ -35,14 +35,19 @@ ignore_missing_imports = "True"
 
 [tool.ruff.lint]
 select = [
+  "ARG", # flake8-unused-arguments
   "B",   # flake8-bugbear
   "BLE", # flake8-blind-except
   "C4",  # flake8-comprehensions
   "E",   # pycodestyle errors
   "F",   # pyflakes
   "I",   # isort
+  "LOG", # flake8-logging
   "N",   # pep8-naming
+  "RET", # flake8-return
+  "RUF", # ruff-specific rules
   "S",   # flake8-bandit
+  "SIM", # flake8-simplify
   "UP",  # pyupgrade
   "W",   # pycodestyle warnings
 ]

--- a/repo/test/test_ci_repository.py
+++ b/repo/test/test_ci_repository.py
@@ -5,7 +5,7 @@ from tuf_on_ci._repository import CIRepository
 
 class TestCIRepository(unittest.TestCase):
     def test_non_existing_repo(self):
-        repo = CIRepository("/tmp/no_such_file")
+        repo = CIRepository("no_such_file")
         self.assertRaises(ValueError, repo.open, "root")
 
     def test_signing_expiry_days_root(self):

--- a/repo/tuf_on_ci/create_signing_events.py
+++ b/repo/tuf_on_ci/create_signing_events.py
@@ -20,7 +20,8 @@ def _git(cmd: list[str]) -> subprocess.CompletedProcess:
         "user.name=TUF-on-CI",
         "-c",
         "user.email=41898282+github-actions[bot]@users.noreply.github.com",
-    ] + cmd
+        *cmd,
+    ]
     proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
     logger.debug("%s:\n%s", cmd, proc.stdout)
     return proc

--- a/repo/tuf_on_ci/online_sign.py
+++ b/repo/tuf_on_ci/online_sign.py
@@ -19,7 +19,8 @@ def _git(cmd: list[str]) -> subprocess.CompletedProcess:
         "user.name=tuf-on-ci",
         "-c",
         "user.email=41898282+github-actions[bot]@users.noreply.github.com",
-    ] + cmd
+        *cmd,
+    ]
     proc = subprocess.run(cmd, check=True, text=True)
     logger.debug("%s:\n%s", cmd, proc.stdout)
     return proc

--- a/repo/tuf_on_ci/signing_event.py
+++ b/repo/tuf_on_ci/signing_event.py
@@ -24,7 +24,8 @@ def _git(cmd: list[str]) -> subprocess.CompletedProcess:
         "user.name=TUF-on-CI",
         "-c",
         "user.email=41898282+github-actions[bot]@users.noreply.github.com",
-    ] + cmd
+        *cmd,
+    ]
     proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
     logger.debug("%s:\n%s", cmd, proc.stdout)
     return proc
@@ -100,10 +101,7 @@ def _role_status(repo: CIRepository, role: str, event_name) -> bool:
         signed = signed | prev_status.signed
         missing = missing | prev_status.missing
 
-    if role_is_valid and not status.invites:
-        emoji = "white_check_mark"
-    else:
-        emoji = "x"
+    emoji = "white_check_mark" if role_is_valid and not status.invites else "x"
     click.echo(f"#### :{emoji}: {role}")
 
     if status.invites:

--- a/signer/pyproject.toml
+++ b/signer/pyproject.toml
@@ -27,14 +27,19 @@ ignore_missing_imports = "True"
 
 [tool.ruff.lint]
 select = [
+  "ARG", # flake8-unused-arguments
   "B",   # flake8-bugbear
   "BLE", # flake8-blind-except
   "C4",  # flake8-comprehensions
   "E",   # pycodestyle errors
   "F",   # pyflakes
   "I",   # isort
+  "LOG", # flake8-logging
   "N",   # pep8-naming
+  "RET", # flake8-return
+  "RUF", # ruff-specific rules
   "S",   # flake8-bandit
+  "SIM", # flake8-simplify
   "UP",  # pyupgrade
   "W",   # pycodestyle warnings
 ]

--- a/signer/pyproject.toml
+++ b/signer/pyproject.toml
@@ -25,7 +25,20 @@ module = [
 ]
 ignore_missing_imports = "True"
 
-[tool.ruff]
-# pycodestyle errors(E) and Pyflakes (F) are enabled by default.
-# Also enable isort (I) and pep8-naming (N) .
-select = ["E", "F", "I", "N"]
+[tool.ruff.lint]
+select = [
+  "B",   # flake8-bugbear
+  "BLE", # flake8-blind-except
+  "C4",  # flake8-comprehensions
+  "E",   # pycodestyle errors
+  "F",   # pyflakes
+  "I",   # isort
+  "N",   # pep8-naming
+  "S",   # flake8-bandit
+  "UP",  # pyupgrade
+  "W",   # pycodestyle warnings
+]
+ignore = [
+  "S101", # Use of `assert` detected
+  "S603", # `subprocess` call: check for execution of untrusted input
+]

--- a/signer/tuf_on_ci_sign/_common.py
+++ b/signer/tuf_on_ci_sign/_common.py
@@ -77,7 +77,7 @@ def get_signing_key_input() -> Key:
 
 
 def git(cmd: list[str]) -> str:
-    cmd = ["git"] + cmd
+    cmd = ["git", *cmd]
     proc = subprocess.run(cmd, capture_output=True, check=True, text=True)
     return proc.stdout.strip()
 
@@ -93,7 +93,7 @@ def git_expect(cmd: list[str]) -> str:
 
 
 def git_echo(cmd: list[str]):
-    cmd = ["git"] + cmd
+    cmd = ["git", *cmd]
     subprocess.run(cmd, check=True, text=True)
 
 

--- a/signer/tuf_on_ci_sign/_common.py
+++ b/signer/tuf_on_ci_sign/_common.py
@@ -70,8 +70,8 @@ def get_signing_key_input() -> Key:
         )
         try:
             _, key = HSMSigner.import_()
-        except Exception as e:
-            raise click.ClickException(f"Failed to read HW key: {e}")
+        except Exception as e:  # noqa: BLE001
+            raise click.ClickException(f"Failed to read HW key: {e}") from e
 
     return key
 

--- a/signer/tuf_on_ci_sign/_signer_repository.py
+++ b/signer/tuf_on_ci_sign/_signer_repository.py
@@ -664,7 +664,7 @@ class SignerRepository(Repository):
                 del old_delegations[name]
 
         for name in old_delegations:
-            output.append(f" * Removed {title}")
+            output.append(f" * Removed {name}")
 
         return output
 

--- a/signer/tuf_on_ci_sign/_signer_repository.py
+++ b/signer/tuf_on_ci_sign/_signer_repository.py
@@ -193,9 +193,9 @@ class SignerRepository(Repository):
                 md = Metadata.from_bytes(f.read())
             assert isinstance(md.signed, Root)
             return md.signed
-        else:
-            # this role did not exist: return an empty one for comparison purposes
-            return Root()
+
+        # this role did not exist: return an empty one for comparison purposes
+        return Root()
 
     def _known_good_targets(self, rolename: str) -> Targets:
         """Return a Targets object from the known-good repository state"""
@@ -205,9 +205,9 @@ class SignerRepository(Repository):
                 md = Metadata.from_bytes(f.read())
             assert isinstance(md.signed, Targets)
             return md.signed
-        else:
-            # this role did not exist: return an empty one for comparison purposes
-            return Targets()
+
+        # this role did not exist: return an empty one for comparison purposes
+        return Targets()
 
     def _get_keys(self, role: str, known_good: bool = False) -> list[Key]:
         """Return public keys for delegated role
@@ -345,9 +345,12 @@ class SignerRepository(Repository):
     def _get_delegated_rolenames(md: Metadata) -> list[str]:
         if isinstance(md.signed, Root):
             return list(md.signed.roles.keys())
-        elif isinstance(md.signed, Targets):
-            if md.signed.delegations and md.signed.delegations.roles:
-                return list(md.signed.delegations.roles.keys())
+        if (
+            isinstance(md.signed, Targets)
+            and md.signed.delegations
+            and md.signed.delegations.roles
+        ):
+            return list(md.signed.delegations.roles.keys())
         return []
 
     def get_online_config(self) -> OnlineConfig:

--- a/signer/tuf_on_ci_sign/_user.py
+++ b/signer/tuf_on_ci_sign/_user.py
@@ -42,7 +42,9 @@ class User:
             self.push_remote = self._config["settings"]["push-remote"]
             self.pull_remote = self._config["settings"]["pull-remote"]
         except KeyError as e:
-            raise click.ClickException(f"Failed to find required setting {e} in {path}")
+            raise click.ClickException(
+                f"Failed to find required setting {e} in {path}"
+            ) from e
 
         # signing key config is not required
         if "signing-keys" in self._config:

--- a/signer/tuf_on_ci_sign/delegate.py
+++ b/signer/tuf_on_ci_sign/delegate.py
@@ -212,8 +212,10 @@ def _collect_online_key(user_config: User) -> Key:
                 uri, key = GCPSigner.import_(key_id)
                 key.unrecognized_fields["x-tuf-on-ci-online-uri"] = uri
                 return key
-            except Exception as e:
-                raise click.ClickException(f"Failed to read Google Cloud KMS key: {e}")
+            except Exception as e:  # noqa: BLE001
+                raise click.ClickException(
+                    f"Failed to read Google Cloud KMS key: {e}"
+                ) from e
         if choice == 3:
             vault_name = _collect_string("Enter Azure vault name")
             key_name = _collect_string("Enter key name")
@@ -221,8 +223,10 @@ def _collect_online_key(user_config: User) -> Key:
                 uri, key = AzureSigner.import_(vault_name, key_name)
                 key.unrecognized_fields["x-tuf-on-ci-online-uri"] = uri
                 return key
-            except Exception as e:
-                raise click.ClickException(f"Failed to read Azure Keyvault key: {e}")
+            except Exception as e:  # noqa: BLE001
+                raise click.ClickException(
+                    f"Failed to read Azure Keyvault key: {e}"
+                ) from e
         if choice == 4:
             key_id = _collect_string("Enter AWS KMS key id")
             scheme = _collect_key_scheme()
@@ -230,8 +234,8 @@ def _collect_online_key(user_config: User) -> Key:
                 uri, key = AWSSigner.import_(key_id, scheme)
                 key.unrecognized_fields["x-tuf-on-ci-online-uri"] = uri
                 return key
-            except Exception as e:
-                raise click.ClickException(f"Failed to read AWS KMS key: {e}")
+            except Exception as e:  # noqa: BLE001
+                raise click.ClickException(f"Failed to read AWS KMS key: {e}") from e
         if choice == 0:
             # This could be generic support, but for now it's a hidden test key.
             # key value 1d9a024348e413892aeeb8cc8449309c152f48177200ee61a02ae56f450c6480

--- a/signer/tuf_on_ci_sign/delegate.py
+++ b/signer/tuf_on_ci_sign/delegate.py
@@ -241,14 +241,13 @@ def _collect_online_key(user_config: User) -> Key:
             # key value 1d9a024348e413892aeeb8cc8449309c152f48177200ee61a02ae56f450c6480
             uri = "envvar:LOCAL_TESTING_KEY"
             pub_key = "fa472895c9756c2b9bcd1440bf867d0fa5c4edee79e9792fa9822be3dd6fcbb3"
-            key = SSlibKey(
+            return SSlibKey(
                 "fa47289",
                 "ed25519",
                 "ed25519",
                 {"public": pub_key},
                 {"x-tuf-on-ci-online-uri": uri},
             )
-            return key
 
 
 def _collect_string(prompt: str) -> str:
@@ -256,8 +255,7 @@ def _collect_string(prompt: str) -> str:
         data = click.prompt(bold(prompt), default="")
         if data == "":
             continue
-        else:
-            return data
+        return data
 
 
 def _collect_key_scheme() -> str:

--- a/signer/tuf_on_ci_sign/delegate.py
+++ b/signer/tuf_on_ci_sign/delegate.py
@@ -252,10 +252,8 @@ def _collect_online_key(user_config: User) -> Key:
 
 def _collect_string(prompt: str) -> str:
     while True:
-        data = click.prompt(bold(prompt), default="")
-        if data == "":
-            continue
-        return data
+        if data := click.prompt(bold(prompt), default=""):
+            return data
 
 
 def _collect_key_scheme() -> str:

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
 
 changedir = signer
 commands =
-    ruff .
+    ruff check .
     ruff format --check --diff .
     mypy .
 
@@ -25,7 +25,7 @@ deps =
 
 changedir = repo
 commands =
-    ruff .
+    ruff check .
     ruff format --check --diff .
     mypy .
 


### PR DESCRIPTION
Enable more linter rulesets. This list is not complete (we can probably still enable another ten rulesets) but it's a good start.

Also:
    * Be explicit about used ruff subcommand in tox.ini
    * Fix the settings path to current tool.ruff.lint
    * As linting result: Fix one output bug
     * Tweak some error handling cases and implement style suggestions