### PR TITLE
signer: Improve failure handling during sign

### DIFF
--- a/signer/tuf_on_ci_sign/_signer_repository.py
+++ b/signer/tuf_on_ci_sign/_signer_repository.py
@@ -248,8 +248,14 @@ class SignerRepository(Repository):
             try:
                 md.sign(signer, True)
                 break
-            except UnsignedMetadataError:
-                print(f"Failed to sign {role} with {self.user.name} key. Try again?")
+            except UnsignedMetadataError as e:
+                print(f"Failed to sign {role} with {self.user.name} key.\n    {e}")
+                logger.debug("Sign traceback", exc_info=True)
+                click.prompt(
+                    "Press any key to try again (Ctrl-C to cancel)",
+                    default=True,
+                    show_default=False,
+                )
 
     def _write(self, role: str, md: Metadata) -> None:
         filename = self._get_filename(role)


### PR DESCRIPTION
* Include the actual failure message in output
* Provide stack trace in debug log
* Allow canceling

Combined with python-tuf main branch this now looks like 

```
$ tuf-on-ci-sign --no-push sign/test-signing-failures
Signing event sign/test-signing-failures (commit 7e6d238)
Your signature is requested for role(s) {'jku'}.

jku v5
 * Removed artifact 'jku/file1'
Enter pin to sign: 
Failed to sign jku with @jku key.
    Failed to sign: CKR_PIN_INCORRECT (0x000000A0)
Press any key to try again (Ctrl-C to cancel): 
```

Not amazing but I think much better than before