### PR TITLE
Release 0.7.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## v0.7.0
+
+**Changes**
+
+* Signer has improved signing error handling
+* Custom fields in TargetFile metadata are now preserved during target update
+  (this is a workaround mostly for sigstore root-signing legacy artifacts)
+
+**Upgrade instructions**
+
+A plain version bump from 0.6 works: Workflows require no changes.
+
 ## v0.6.0
 
 **NOTE:** please see upgrade instructions below.

--- a/repo/pyproject.toml
+++ b/repo/pyproject.toml
@@ -8,7 +8,7 @@ allow-direct-references = true
 
 [project]
 name = "tuf-on-ci"
-version = "0.6.0"
+version = "0.7.0"
 description = "TUF-on-CI repository tools, intended to be executed on a CI system"
 readme = "README.md"
 dependencies = [

--- a/signer/pyproject.toml
+++ b/signer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tuf-on-ci-sign"
-version = "0.6.0"
+version = "0.7.0"
 description = "Signing tools for TUF-on-CI"
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
* Signer has improved signing error handling
* Custom fields in TargetFile metadata are now preserved during target update
  (this is a workaround mostly for sigstore root-signing legacy artifacts)