### PR TITLE
signer: Increase signing robustness

### DIFF
--- a/signer/test/test_user.py
+++ b/signer/test/test_user.py
@@ -94,6 +94,9 @@ class TestUser(unittest.TestCase):
                 "762cb22caca65de5e9b7b6baecb84ca989d337280ce6914b6440aea95769ad93",
             )
 
+            # Cache the signer
+            user.set_signer(HSM_KEY, hsm_signer)
+
             # If the signing key is not configured, we expect a generic HSM signer
             other_signer = user.get_signer(NONCONFIGURED_KEY)
             self.assertIsInstance(other_signer, HSMSigner)

--- a/signer/tuf_on_ci_sign/_signer_repository.py
+++ b/signer/tuf_on_ci_sign/_signer_repository.py
@@ -254,7 +254,10 @@ class SignerRepository(Repository):
                 print(f"Failed to sign {role} with {self.user.name} key.\n    {e}")
                 logger.debug("Sign traceback", exc_info=True)
             except UnverifiedSignatureError as e:
-                print(f"Signature fails to verify with {self.user.name} key.\n    {e}")
+                print(
+                    f"Failed to verify {self.user.name} signature "
+                    f"(is this the correct key?)\n    {e}"
+                )
                 logger.debug("Verify traceback", exc_info=True)
 
             click.prompt(


### PR DESCRIPTION
* Make sure we re-initialize the signer when trying to sign again after a failure (this makes sense if e.g. yubikey has been switched midsigning)
* verify the signature after signing
* Only cache signers after a successful signing