### PR TITLE
Test repository improvements

### DIFF
--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -39,7 +39,9 @@ runs:
       with:
         python-version: "3.11"
 
-    - run: pip --quiet install $GITHUB_ACTION_PATH/../../repo/
+    - run: |
+        # Install tuf-on-ci
+        pip --quiet install $GITHUB_ACTION_PATH/../../repo/
       shell: bash
 
     - env:
@@ -53,6 +55,8 @@ runs:
         OFFLINE_VALID_DAYS: ${{ inputs.offline_valid_days }}
         METADATA_DIR: ${{ inputs.metadata_dir }}
       run: |
+        # Run tuf-on-ci test client
+
         OWNER=${OWNER_REPO%/*}
         REPO=${OWNER_REPO#*/}
 

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -61,7 +61,7 @@ runs:
           METADATA_URL="https://${OWNER}.github.io/${REPO}/metadata/"
         fi
         if [ -z $ARTIFACT_URL ]; then
-          ARTIFACT_URL="https://${OWNER}.github.io/${REPO}/targets/"
+          ARTIFACT_URL=${METADATA_URL%metadata/}targets/
         fi
 
         if [ -z $UPDATE_BASE_URL ]; then

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -11,6 +11,12 @@ inputs:
   expected_artifact:
     description: 'Optional artifact path that should be checked to exist in the repository'
     default: ''
+  time:
+    description: 'Optional timestamp. The repository is checked to be valid at this time'
+    default: ''
+  offline_time:
+    description: 'Optional timestamp. Root and targets role validity is checked at this time'
+    default: ''
 
 runs:
   using: "composite"
@@ -31,6 +37,8 @@ runs:
         ARTIFACT_URL: ${{ inputs.artifact_url }}
         EXPECTED_ARTIFACT: ${{ inputs.expected_artifact }}
         OWNER_REPO: ${{ github.repository }}
+        TIME: ${{ inputs.time }}
+        OFFLINE_TIME: ${{ inputs.offline_time }}
       run: |
         OWNER=${OWNER_REPO%/*}
         REPO=${OWNER_REPO#*/}
@@ -43,16 +51,30 @@ runs:
           ARTIFACT_URL="https://${OWNER}.github.io/${REPO}/targets/"
         fi
 
-        # set --expected-artifact if input is used
         if [ -z $EXPECTED_ARTIFACT ]; then
           ARTIFACT_ARG=""
         else
           ARTIFACT_ARG="--expected-artifact $EXPECTED_ARTIFACT"
         fi
 
+        if [ -z $TIME ]; then
+          TIME_ARG=""
+        else
+          TIME_ARG="--time $TIME"
+        fi
+
+        if [ -z $OFFLINE_TIME ]; then
+          OFFLINE_TIME_ARG=""
+        else
+          OFFLINE_TIME_ARG="--offline-time $OFFLINE_TIME"
+        fi
+
         echo "Testing repository at metadata-url $METADATA_URL, artifact-url $ARTIFACT_URL"
         tuf-on-ci-test-client \
           --metadata-url "$METADATA_URL" \
           --artifact-url "$ARTIFACT_URL" \
-          $ARTIFACT_ARG
+          $ARTIFACT_ARG \
+          $TIME_ARG \
+          $OFFLINE_TIME_ARG
+
       shell: bash

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -56,7 +56,6 @@ runs:
         METADATA_DIR: ${{ inputs.metadata_dir }}
       run: |
         # Run tuf-on-ci test client
-
         OWNER=${OWNER_REPO%/*}
         REPO=${OWNER_REPO#*/}
 

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -8,6 +8,9 @@ inputs:
   artifact_url:
     description: 'Base artifact URL the client should use'
     default: ''
+  update_base_url:
+    description: 'Optional metadata URL to use as previous repository state'
+    default: ''
   expected_artifact:
     description: 'Optional artifact path that should be checked to exist in the repository'
     default: ''
@@ -19,6 +22,9 @@ inputs:
     default: ''
   offline_time:
     description: 'Optional timestamp. Root and targets role validity is checked at this time'
+    default: ''
+  metadata_dir:
+    description: 'Optional directory name. The metadata client receives will be stored here. Useful e.g. for deduplication purpose'
     default: ''
 
 runs:
@@ -38,11 +44,13 @@ runs:
     - env:
         METADATA_URL: ${{ inputs.metadata_url }}
         ARTIFACT_URL: ${{ inputs.artifact_url }}
+        UPDATE_BASE_URL: ${{ inputs.update_base_url }}
         EXPECTED_ARTIFACT: ${{ inputs.expected_artifact }}
         OWNER_REPO: ${{ github.repository }}
         COMPARE_SOURCE: ${{ inputs.compare_source }}
         TIME: ${{ inputs.time }}
         OFFLINE_TIME: ${{ inputs.offline_time }}
+        METADATA_DIR: ${{ inputs.metadata_dir }}
       run: |
         OWNER=${OWNER_REPO%/*}
         REPO=${OWNER_REPO#*/}
@@ -53,6 +61,12 @@ runs:
         fi
         if [ -z $ARTIFACT_URL ]; then
           ARTIFACT_URL="https://${OWNER}.github.io/${REPO}/targets/"
+        fi
+
+        if [ -z $UPDATE_BASE_URL ]; then
+          UPDATE_BASE_URL_ARG=""
+        else
+          UPDATE_BASE_URL_ARG="--update-base-url $UPDATE_BASE_URL"
         fi
 
         if [ -z $EXPECTED_ARTIFACT ]; then
@@ -79,13 +93,21 @@ runs:
           OFFLINE_TIME_ARG="--offline-time $OFFLINE_TIME"
         fi
 
+        if [ -z $METADATA_DIR ]; then
+          METADATA_DIR_ARG=""
+        else
+          METADATA_DIR_ARG="--metadata-dir $METADATA_DIR"
+        fi
+
         echo "Testing repository at metadata-url $METADATA_URL, artifact-url $ARTIFACT_URL"
         tuf-on-ci-test-client \
           --metadata-url "$METADATA_URL" \
           --artifact-url "$ARTIFACT_URL" \
+          $UPDATE_BASE_URL_ARG \
           $ARTIFACT_ARG \
           $COMPARE_SOURCE_ARG \
           $TIME_ARG \
-          $OFFLINE_TIME_ARG
+          $OFFLINE_TIME_ARG \
+          $METADATA_DIR_ARG
 
       shell: bash

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -17,12 +17,12 @@ inputs:
   compare_source:
     description: 'When true, client metadata is compared to current repository content. Set to false if action is not running in a tuf-on-ci repository'
     default: 'true'
-  time:
-    description: 'Optional timestamp. The repository is checked to be valid at this time'
-    default: ''
-  offline_time:
-    description: 'Optional timestamp. Root and targets role validity is checked at this time'
-    default: ''
+  valid_days:
+    description: 'Number of days. The repository is checked to be valid at "now + N days"'
+    default: '0'
+  offline_valid_days:
+    description: 'Number of days. Root and targets role validity is checked to be valid at "now + N days". Can be larger than repository validity'
+    default: '0'
   metadata_dir:
     description: 'Optional directory name. The metadata client receives will be stored here. Useful e.g. for deduplication purpose'
     default: ''
@@ -48,8 +48,8 @@ runs:
         EXPECTED_ARTIFACT: ${{ inputs.expected_artifact }}
         OWNER_REPO: ${{ github.repository }}
         COMPARE_SOURCE: ${{ inputs.compare_source }}
-        TIME: ${{ inputs.time }}
-        OFFLINE_TIME: ${{ inputs.offline_time }}
+        VALID_DAYS: ${{ inputs.valid_days }}
+        OFFLINE_VALID_DAYS: ${{ inputs.offline_valid_days }}
         METADATA_DIR: ${{ inputs.metadata_dir }}
       run: |
         OWNER=${OWNER_REPO%/*}
@@ -81,15 +81,17 @@ runs:
           COMPARE_SOURCE_ARG="--no-compare-source"
         fi
 
-        if [ -z $TIME ]; then
+        if [ $VALID_DAYS -eq 0 ]; then
           TIME_ARG=""
         else
+          TIME=$(date -d "+$VALID_DAYS days" '+%s')
           TIME_ARG="--time $TIME"
         fi
 
-        if [ -z $OFFLINE_TIME ]; then
+        if [ $OFFLINE_VALID_DAYS -eq 0 ]; then
           OFFLINE_TIME_ARG=""
         else
+          OFFLINE_TIME=$(date -d "+$OFFLINE_VALID_DAYS days" '+%s')
           OFFLINE_TIME_ARG="--offline-time $OFFLINE_TIME"
         fi
 

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -31,6 +31,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      if: inputs.compare_source == 'true'
       with:
         ref: "publish"
 

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -11,6 +11,9 @@ inputs:
   expected_artifact:
     description: 'Optional artifact path that should be checked to exist in the repository'
     default: ''
+  compare_source:
+    description: 'When true, client metadata is compared to current repository content. Set to false if action is not running in a tuf-on-ci repository'
+    default: 'true'
   time:
     description: 'Optional timestamp. The repository is checked to be valid at this time'
     default: ''
@@ -37,6 +40,7 @@ runs:
         ARTIFACT_URL: ${{ inputs.artifact_url }}
         EXPECTED_ARTIFACT: ${{ inputs.expected_artifact }}
         OWNER_REPO: ${{ github.repository }}
+        COMPARE_SOURCE: ${{ inputs.compare_source }}
         TIME: ${{ inputs.time }}
         OFFLINE_TIME: ${{ inputs.offline_time }}
       run: |
@@ -57,6 +61,12 @@ runs:
           ARTIFACT_ARG="--expected-artifact $EXPECTED_ARTIFACT"
         fi
 
+        if [ "$COMPARE_SOURCE" = "true" ]; then
+          COMPARE_SOURCE_ARG="--compare-source"
+        else
+          COMPARE_SOURCE_ARG="--no-compare-source"
+        fi
+
         if [ -z $TIME ]; then
           TIME_ARG=""
         else
@@ -74,6 +84,7 @@ runs:
           --metadata-url "$METADATA_URL" \
           --artifact-url "$ARTIFACT_URL" \
           $ARTIFACT_ARG \
+          $COMPARE_SOURCE_ARG \
           $TIME_ARG \
           $OFFLINE_TIME_ARG
 

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -3,28 +3,39 @@ description: 'Test a published TUF-on-CI repository with a client'
 
 inputs:
   metadata_url:
-    description: 'base metadata URL the client should use'
+    description: |
+      base metadata URL the client should use. The client will be initialized with
+      `metadata_url/1.root.json` by default. However if there is a `root.json` file
+      in the working directory, that will be used instead.
     default: ''
   artifact_url:
-    description: 'Base artifact URL the client should use'
+    description: 'Base artifact URL the client should use.'
     default: ''
   update_base_url:
-    description: 'Optional metadata URL to use as previous repository state'
+    description: 'Optional metadata URL to use as previous repository state.'
     default: ''
   expected_artifact:
-    description: 'Optional artifact path that should be checked to exist in the repository'
+    description: |
+      Optional artifact path that should be checked to exist in the repository.
     default: ''
   compare_source:
-    description: 'When true, client metadata is compared to current repository content. Set to false if action is not running in a tuf-on-ci repository'
+    description: |
+      When true, client metadata is compared to current repository content. Set to
+      false if action is not running in a tuf-on-ci repository.
     default: 'true'
   valid_days:
-    description: 'Number of days. The repository is checked to be valid at "now + N days"'
+    description: |
+      Number of days. The repository is checked to be valid at "now + N days".
     default: '0'
   offline_valid_days:
-    description: 'Number of days. Root and targets role validity is checked to be valid at "now + N days". Can be larger than repository validity'
+    description: |
+      Number of days. Root and targets role validity is checked to be valid at
+      "now + N days". This number can be larger than repository validity.
     default: '0'
   metadata_dir:
-    description: 'Optional directory name. The metadata client receives will be stored here. Useful e.g. for deduplication purpose'
+    description: |
+      Optional directory name. The metadata client receives will be left here.
+      Useful e.g. for deduplication purposes.
     default: ''
 
 runs:
@@ -105,11 +116,18 @@ runs:
           METADATA_DIR_ARG="--metadata-dir $METADATA_DIR"
         fi
 
+        if [ -e root.json ]; then
+          ROOT_ARG="--initial-root root.json"
+        else
+          ROOT_ARG=""
+        fi
+
         echo "Testing repository at metadata-url $METADATA_URL, artifact-url $ARTIFACT_URL"
         tuf-on-ci-test-client \
           --metadata-url "$METADATA_URL" \
           --artifact-url "$ARTIFACT_URL" \
           $UPDATE_BASE_URL_ARG \
+          $ROOT_ARG \
           $ARTIFACT_ARG \
           $COMPARE_SOURCE_ARG \
           $TIME_ARG \

--- a/repo/tuf_on_ci/client.py
+++ b/repo/tuf_on_ci/client.py
@@ -5,11 +5,11 @@
 
 import logging
 import os
-import shutil
 import sys
 from datetime import datetime
 from filecmp import cmp
 from tempfile import TemporaryDirectory
+from urllib import request
 
 import click
 from tuf.api.exceptions import ExpiredMetadataError
@@ -22,7 +22,7 @@ def expiry_check(dir: str, role: str, timestamp: int):
     md = Metadata.from_file(os.path.join(dir, f"{role}.json"))
     expiry = md.signed.expires
     if ref_time > expiry:
-        sys.exit(f"Error: {role} expires {expiry} (expected after {ref_time})")
+        sys.exit(f"Error: {role} expires {expiry} (expected valid at {ref_time})")
     print(f"Role {role} is valid on {ref_time}: OK")
 
 @click.command()
@@ -30,20 +30,15 @@ def expiry_check(dir: str, role: str, timestamp: int):
 @click.option("-m", "--metadata-url", type=str, required=True)
 @click.option("-a", "--artifact-url", type=str, required=True)
 @click.option("-e", "--expected-artifact", type=str)
-@click.option(
-    "-c",
-    "--metadata-cache",
-    type=str,
-    help="Optional client cache dir that client should use",
-)
+@click.option("--compare-source/--no-compare-source", default=True)
 @click.option("-t", "--time", type=int)
-@click.option("--offline-time", type=int)
+@click.option("-o", "--offline-time", type=int)
 def client(
     verbose: int,
     metadata_url: str,
     artifact_url: str,
     expected_artifact: str | None,
-    metadata_cache: str | None,
+    compare_source: bool,
     time: int | None,
     offline_time: int | None,
 ) -> None:
@@ -61,16 +56,11 @@ def client(
         os.mkdir(metadata_dir)
         os.mkdir(artifact_dir)
 
-        if metadata_cache:
-            # pre-populate the client cache with given directory
-            for fname in os.listdir(metadata_cache):
-                fpath = os.path.join(metadata_cache, fname)
-                if os.path.isfile(fpath):
-                    shutil.copy(fpath, os.path.join(metadata_dir, fname))
-        else:
-            # pre-populate the client cache with first root version from source
-            root = "metadata/root_history/1.root.json"
-            shutil.copy(root, os.path.join(metadata_dir, "root.json"))
+        root_url = f"{metadata_url}/1.root.json"
+        try:
+            request.urlretrieve(root_url, f"{metadata_dir}/root.json")  # noqa: S310
+        except OSError as e:
+            sys.exit(f"Failed to download initial root {root_url}: {e}")
 
         updater = Updater(metadata_dir, metadata_url, artifact_dir, artifact_url)
         ref_time_string = ""
@@ -80,20 +70,23 @@ def client(
             updater._trusted_set.reference_time = datetime.fromtimestamp(time)
             ref_time_string = f" (reference time {updater._trusted_set.reference_time})"
 
-        # For now, just confirm we can get top level metadata from remote
+        # Confirm we can get valid top level metadata from remote
         try:
             updater.refresh()
         except ExpiredMetadataError as e:
             sys.exit(f"Update{ref_time_string} failed: {e}")
         print(f"Client metadata update{ref_time_string}: OK")
 
-        # Verify the received metadata versions are what was expected
-        for f in ["root.json", "timestamp.json"]:
-            if not cmp(f"metadata/{f}", os.path.join(metadata_dir, f), shallow=False):
-                sys.exit(f"Error: Client metadata does not match sources: {f} failed")
-        print("Client metadata matches sources: OK")
+        if compare_source:
+            # Compare received metadata versions with source metadata
+            for f in ["root.json", "timestamp.json"]:
+                client_file = os.path.join(metadata_dir, f)
+                source_file = os.path.join("metadata", f)
+                if not cmp(source_file, client_file, shallow=False):
+                    sys.exit(f"Error: metadata does not match sources: {f} failed")
+            print("Client metadata matches sources: OK")
 
-        # Verify root and targets are valid at given reference times
+        # Verify root and targets are valid at given reference time
         if offline_time is not None:
             expiry_check(metadata_dir, "root", offline_time)
             expiry_check(metadata_dir, "targets", offline_time)

--- a/repo/tuf_on_ci/client.py
+++ b/repo/tuf_on_ci/client.py
@@ -25,6 +25,7 @@ def expiry_check(dir: str, role: str, timestamp: int):
         sys.exit(f"Error: {role} expires {expiry} (expected valid at {ref_time})")
     print(f"Role {role} is valid on {ref_time}: OK")
 
+
 @click.command()
 @click.option("-v", "--verbose", count=True, default=0)
 @click.option("-m", "--metadata-url", type=str, required=True)
@@ -78,14 +79,15 @@ def client(
         if time is not None:
             # HACK: replace reference time with ours: initial root has been loaded
             # already but that is fine: the expiry check only happens during refresh
-            updater._trusted_set.reference_time = datetime.fromtimestamp(time)
-            ref_time_string = f" (reference time {updater._trusted_set.reference_time})"
+            ref_time = datetime.fromtimestamp(time)
+            updater._trusted_set.reference_time = ref_time
+            ref_time_string = f" at reference time {ref_time}"
 
         # Confirm we can get valid top level metadata from remote
         try:
             updater.refresh()
         except ExpiredMetadataError as e:
-            sys.exit(f"Update{ref_time_string} failed: {e}")
+            sys.exit(f"Error: Update failed: {e}{ref_time_string}")
         print(f"Client metadata update from {metadata_url}{ref_time_string}: OK")
 
         if compare_source:

--- a/repo/tuf_on_ci/client.py
+++ b/repo/tuf_on_ci/client.py
@@ -67,13 +67,14 @@ def client(
 
         if update_base_url is not None:
             # Update client to update_base_url before doing the actual update
-            updater = Updater(metadata_dir, metadata_url, artifact_dir, artifact_url)
+            updater = Updater(metadata_dir, update_base_url, artifact_dir, artifact_url)
             try:
                 updater.refresh()
                 print(f"Client metadata update from base url {update_base_url}: OK")
             except ExpiredMetadataError as e:
                 print(f"WARNING: update base url has expired metadata: {e}")
 
+        # Update client to metadata_url
         updater = Updater(metadata_dir, metadata_url, artifact_dir, artifact_url)
         ref_time_string = ""
         if time is not None:


### PR DESCRIPTION
Add multiple optional arguments to the action

This one is for upgrade testing after a signing event:
* Add upgrade testing with `update_base_url`: this allows testing that the new repository is a compliant upgrade from an existing repository version. This is useful when we have a "prod" and "preprod" environments and a  new "preprod" deployment is being tested: in this case "prod" can be used as the `update_base_url`

All of the following are reasonable use cases from sigstore-probers (so out-of-tree testing for alerting purposes):
* Add `compare_source` option to allow running the test without being inside a tuf-on-ci repository (when 'false', the metadata versions are not verified to be specific ones)
* Add `metadata_dir` to allow using the client metadata for e.g. deduplication like sigstore-prober wants to do
* Add `valid_days` to allow verifying if the repository is valid at a specific time in the future
* add `offline_valid_days` to allow verifying that root and targets metadata are valid at  a specific time (even if repository is not)
