### PR TITLE
repo, signer: Pin securesystemslib better

### DIFF
--- a/repo/pyproject.toml
+++ b/repo/pyproject.toml
@@ -11,7 +11,7 @@ name = "tuf-on-ci"
 description = "TUF-on-CI repository tools, intended to be executed on a CI system"
 readme = "README.md"
 dependencies = [
-  "securesystemslib[awskms, azurekms, gcpkms, sigstore, pynacl] ~= 0.30",
+  "securesystemslib[awskms, azurekms, gcpkms, sigstore, pynacl] ~= 0.31.0",
   "tuf ~= 3.0",
   "click ~= 8.1",
 ]

--- a/signer/pyproject.toml
+++ b/signer/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 dependencies = [
   "packaging >= 23.2,< 25.0",
   "platformdirs ~= 4.2",
-  "securesystemslib[awskms,azurekms,gcpkms,hsm,sigstore] ~= 0.30",
+  "securesystemslib[awskms,azurekms,gcpkms,hsm,sigstore] ~= 0.31.0",
   "tuf ~= 3.0",
   "click ~= 8.1",
 ]


### PR DESCRIPTION
Securesystemslib is "pre 1.0" so the normal pinning does not really work: the new pinning "~= 0.31.0" should lead to 0.31.1 to be accepted but not 0.32.0.