### PR TITLE
Release v0.9

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## v0.9.0
+
+GitHub Actions users are adviced to upgrade for safer dependency
+pinning that should avoid breakage in future.
+
+**Changes**
+
+* actions: test-repository action has many additional features (#239)
+* actions: python package versions are now in logs again (#247)
+* signer: Improve signing robustness (#237)
+* Dependency updates (including more strictly pinned securesystemslib)
+
+**GitHub Actions upgrade instructions**
+
+A plain version bump from 0.8 works: Workflows require no changes.
+
 ## v0.8.0
 
 **Changes**

--- a/repo/tuf_on_ci/__init__.py
+++ b/repo/tuf_on_ci/__init__.py
@@ -4,7 +4,7 @@ from tuf_on_ci.create_signing_events import create_signing_events
 from tuf_on_ci.online_sign import online_sign
 from tuf_on_ci.signing_event import status, update_targets
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 __all__ = [
     "build_repository",

--- a/signer/tuf_on_ci_sign/__init__.py
+++ b/signer/tuf_on_ci_sign/__init__.py
@@ -2,6 +2,6 @@ from tuf_on_ci_sign.delegate import delegate
 from tuf_on_ci_sign.import_repo import import_repo
 from tuf_on_ci_sign.sign import sign
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 __all__ = ["delegate", "import_repo", "sign"]


### PR DESCRIPTION
**Changes**

* actions: test-repository action has many additional features (#239)
* actions: python package versions are now in logs again (#247)
* signer: Improve signing robustness (#237)
* Dependency updates (including more strictly pinned securesystemslib)