### PR TITLE
Pin all the deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
     interval: "daily"
     time: "10:25"
 
+- package-ecosystem: "pip"
+  directory: "/"
+  schedule:
+    interval: "daily"
+    time: "10:25"
+
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         echo "PYKCS11LIB=/usr/lib/softhsm/libsofthsm2.so" >> $GITHUB_ENV
 
     - name: Install tox
-      run: python -m pip install tox
+      run: python -m pip install -c build-constraints.txt tox
 
     - name: Lint
       run: tox -m lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Lint & test
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions: {}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install build dependencies
-        run: python3 -m pip install --constraint build-constraints.txt build
+        run: python3 -m pip install -c build-constraints.txt build
 
       - name: Build binary wheel and source tarball
         run: PIP_CONSTRAINT=build-constraints.txt python3 -m build --sdist --wheel --outdir dist/ signer/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
           python-version: '3.11'
 
       - name: Install build dependencies
-        run: python3 -m pip install build
+        run: python3 -m pip install --constraint build-constraints.txt build
 
       - name: Build binary wheel and source tarball
-        run: python3 -m build --sdist --wheel --outdir dist/ signer/
+        run: PIP_CONSTRAINT=build-constraints.txt python3 -m build --sdist --wheel --outdir dist/ signer/
 
       - name: Store build artifacts
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1

--- a/.github/workflows/update-pinned-deps.yml
+++ b/.github/workflows/update-pinned-deps.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Install pip-tools
         run: pip install pip-tools
 
-      - name: Update actions/requirements.txt
+      - name: Update repo/install/requirements.txt
         id: update
         run: |
-          pip-compile --strip-extras --upgrade --output-file actions/requirements.txt repo/pyproject.toml
+          pip-compile --strip-extras --upgrade --output-file repo/install/requirements.txt repo/pyproject.toml
           if git diff --quiet; then
             echo "No dependency updates."
             echo "updated=false" >> $GITHUB_OUTPUT
@@ -44,9 +44,9 @@ jobs:
         run: |
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git add actions/requirements.txt
-          git commit -m "actions: Update pinned requirements"
-          SHA=$(sha256sum actions/requirements.txt)
+          git add repo/install/requirements.txt
+          git commit -m "repo: Update pinned requirements"
+          SHA=$(sha256sum repo/install/requirements.txt)
           NAME="pin-requirements/${SHA:0:7}"
           if git ls-remote --exit-code origin $NAME; then
             echo "Branch $NAME exists, nothing to do."

--- a/.github/workflows/update-pinned-deps.yml
+++ b/.github/workflows/update-pinned-deps.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Update actions/requirements.txt
         id: update
         run: |
-          pip-compile --generate-hashes --upgrade --output-file actions/requirements.txt repo/pyproject.toml
+          pip-compile --strip-extras --upgrade --output-file actions/requirements.txt repo/pyproject.toml
           if git diff --quiet; then
             echo "No dependency updates."
             echo "updated=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-pinned-deps.yml
+++ b/.github/workflows/update-pinned-deps.yml
@@ -1,0 +1,74 @@
+name: Update pinned Python dependencies for the actions
+
+on:
+  push:
+    branches: [main]
+    paths: ['repo/pyproject.toml']
+  schedule:
+    - cron:  '21 9 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for pushing a branch
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: "3.11"
+
+      - name: Install pip-tools
+        run: pip install pip-tools
+
+      - name: Update actions/requirements.txt
+        id: update
+        run: |
+          pip-compile --generate-hashes --upgrade --output-file actions/requirements.txt repo/pyproject.toml
+          if git diff --quiet; then
+            echo "No dependency updates."
+            echo "updated=false" >> $GITHUB_OUTPUT
+          else
+            echo "updated=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Push branch
+        id: push
+        if: steps.update.outputs.updated == 'true'
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add actions/requirements.txt
+          git commit -m "actions: Update pinned requirements"
+          SHA=$(sha256sum actions/requirements.txt)
+          NAME="pin-requirements/${SHA:0:7}"
+          if git ls-remote --exit-code origin $NAME; then
+            echo "Branch $NAME exists, nothing to do."
+            echo "pushed=false" >> $GITHUB_OUTPUT
+          else
+            git push origin HEAD:$NAME
+            echo "Pushed branch $NAME."
+            echo "pushed=true" >> $GITHUB_OUTPUT
+            echo "branch=$NAME" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Open pull request
+        if: steps.push.outputs.pushed == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          BRANCH: ${{ steps.push.outputs.branch }}
+        with:
+          script: |
+            await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "actions: Update pinned requirements",
+              head: process.env.BRANCH,
+              base: "main",
+            })

--- a/.github/workflows/update-pinned-deps.yml
+++ b/.github/workflows/update-pinned-deps.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install pip-tools
-        run: pip install pip-tools
+        run: pip install -c build-constraints.txt pip-tools
 
       - name: Update repo/install/requirements.txt
         id: update

--- a/actions/create-signing-events/action.yml
+++ b/actions/create-signing-events/action.yml
@@ -20,7 +20,8 @@ runs:
 
     - run: |
         echo "::group::Install tuf-on-ci"
-        pip install -c $GITHUB_ACTION_PATH/../requirements.txt $GITHUB_ACTION_PATH/../../repo/
+        REPO=$GITHUB_ACTION_PATH/../../repo/
+        pip install -c $REPO/install/requirements.txt $REPO
         echo "::endgroup::"
       shell: bash
 

--- a/actions/create-signing-events/action.yml
+++ b/actions/create-signing-events/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - run: |
         echo "::group::Install tuf-on-ci"
-        pip install $GITHUB_ACTION_PATH/../../repo/
+        pip install -c $GITHUB_ACTION_PATH/../requirements.txt $GITHUB_ACTION_PATH/../../repo/
         echo "::endgroup::"
       shell: bash
 

--- a/actions/online-sign/action.yml
+++ b/actions/online-sign/action.yml
@@ -51,7 +51,8 @@ runs:
 
     - run: |
         echo "::group::Install tuf-on-ci"
-        pip install -c $GITHUB_ACTION_PATH/../requirements.txt $GITHUB_ACTION_PATH/../../repo/
+        REPO=$GITHUB_ACTION_PATH/../../repo/
+        pip install -c $REPO/install/requirements.txt $REPO
         echo "::endgroup::"
       shell: bash
 

--- a/actions/online-sign/action.yml
+++ b/actions/online-sign/action.yml
@@ -51,7 +51,7 @@ runs:
 
     - run: |
         echo "::group::Install tuf-on-ci"
-        pip install $GITHUB_ACTION_PATH/../../repo/
+        pip install -c $GITHUB_ACTION_PATH/../requirements.txt $GITHUB_ACTION_PATH/../../repo/
         echo "::endgroup::"
       shell: bash
 

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -35,7 +35,8 @@ runs:
 
     - run: |
         echo "::group::Install tuf-on-ci"
-        pip install -c $GITHUB_ACTION_PATH/../requirements.txt $GITHUB_ACTION_PATH/../../repo/
+        REPO=$GITHUB_ACTION_PATH/../../repo/
+        pip install -c $REPO/install/requirements.txt $REPO
         echo "::endgroup::"
       shell: bash
 

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -35,7 +35,7 @@ runs:
 
     - run: |
         echo "::group::Install tuf-on-ci"
-        pip install $GITHUB_ACTION_PATH/../../repo/
+        pip install -c $GITHUB_ACTION_PATH/../requirements.txt $GITHUB_ACTION_PATH/../../repo/
         echo "::endgroup::"
       shell: bash
 

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -52,7 +52,7 @@ runs:
 
     - run: |
         echo "::group::Install tuf-on-ci"
-        pip install $GITHUB_ACTION_PATH/../../repo/
+        pip install -c $GITHUB_ACTION_PATH/../requirements.txt $GITHUB_ACTION_PATH/../../repo/
         echo "::endgroup::"
       shell: bash
 

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -52,7 +52,8 @@ runs:
 
     - run: |
         echo "::group::Install tuf-on-ci"
-        pip install -c $GITHUB_ACTION_PATH/../requirements.txt $GITHUB_ACTION_PATH/../../repo/
+        REPO=$GITHUB_ACTION_PATH/../../repo/
+        pip install -c $REPO/install/requirements.txt $REPO
         echo "::endgroup::"
       shell: bash
 

--- a/actions/upload-repository/action.yml
+++ b/actions/upload-repository/action.yml
@@ -32,7 +32,8 @@ runs:
 
     - run: |
         echo "::group::Install tuf-on-ci"
-        pip install -c $GITHUB_ACTION_PATH/../requirements.txt $GITHUB_ACTION_PATH/../../repo/
+        REPO=$GITHUB_ACTION_PATH/../../repo/
+        pip install -c $REPO/install/requirements.txt $REPO
         echo "::endgroup::"
       shell: bash
 

--- a/actions/upload-repository/action.yml
+++ b/actions/upload-repository/action.yml
@@ -30,7 +30,10 @@ runs:
       with:
         python-version: "3.11"
 
-    - run: pip --quiet install $GITHUB_ACTION_PATH/../../repo/
+    - run: |
+        echo "::group::Install tuf-on-ci"
+        pip install -c $GITHUB_ACTION_PATH/../requirements.txt $GITHUB_ACTION_PATH/../../repo/
+        echo "::endgroup::"
       shell: bash
 
     - id: build-repository

--- a/build-constraints.txt
+++ b/build-constraints.txt
@@ -1,0 +1,7 @@
+# these packages are used as constraints during build
+build==1.2.1
+hatchling==1.22.4
+
+# These packages are used used as constraints in workflows
+tox==4.1.2
+pip-tools==7.4.1

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,9 @@ commands =
 [testenv:lint-repo]
 description = Repository Linting
 labels = lint
-deps = -e repo[lint]
+deps = 
+    -c repo/install/requirements.txt
+    -e repo[lint]
 changedir = repo
 commands =
     ruff check .
@@ -25,8 +27,8 @@ commands =
 description = Repository unit tests
 labels = test
 deps =
-    -e repo/
-
+    -c repo/install/requirements.txt
+    -e repo
 changedir = repo
 commands =
     python -m unittest
@@ -34,8 +36,7 @@ commands =
 [testenv:test-signer]
 description = Signer unit tests
 labels = test
-deps =
-    -e signer/
+deps = -e signer
 
 changedir = signer
 commands =
@@ -46,8 +47,9 @@ commands =
 description = End-to-end tests with mocked GitHub Actions
 labels = test
 deps =
-    -e repo/
-    -e signer/
+    -c repo/install/requirements.txt
+    -e repo
+    -e signer
     pynacl
 
 changedir = tests


### PR DESCRIPTION
### Pin all (even indirect) dependencies when running `repo/` in GH actions
* `requirements.txt` is rebuilt by running pip-compile on `repo/pyproject.toml`
* this build happens in a new workflow that runs once a week and creates a PR if something changed
* requirements.txt is used as a constraint when installing `repo/` within the actions

Some drawbacks of this approach:
* We're doing this manually like some kind of cavepeople: bugs are inevitable in 70 lines yaml
* The reason for doing it manually is that as far as I can tell dependabot cannot manage adding/removing indirect dependencies as needed. As a result the PR lacks all links and details that Dependabot PRs have
* We _could_ run this in addition to running Dependabot on requirements.txt: this way normal upgrades could be handled by dependabot and the caveman approach would be used for added/removed deps -- the downside here is dealing with potentially duplicate PRs
* pip is difficult so hashes are not used in this version (you can't use hashes as constraints if the thing you're installing does not have hashes)...

If I should be using a tool that would make this easier please let me know.

CC @lukpueh @woodruffw in case you want to have a look since I complained to both of you about this...