### PR TITLE
workflow: Update CI workflow & dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,22 +2,35 @@ version: 2
 updates:
 
 - package-ecosystem: "pip"
-  directory: "signer/"
-  schedule:
-    interval: "daily"
-    time: "10:25"
-
-- package-ecosystem: "pip"
-  directory: "repo/"
-  schedule:
-    interval: "daily"
-    time: "10:25"
-
-- package-ecosystem: "pip"
   directory: "/"
   schedule:
-    interval: "daily"
-    time: "10:25"
+    interval: "weekly"
+  groups:
+    build-dependencies:
+      # Critical build/release dependencies
+      patterns:
+        - "build"
+        - "hatchling"
+        - "pip-tools"
+    test-dependencies:
+      # Python dependencies that are only pinned to ensure test reproducibility
+      patterns:
+        - "mypy"
+        - "ruff"
+        - "tox"
+    pyproject-dependencies:
+      # Dependency ranges set in signer & repo pyproject.toml. Also any new
+      # dependencies not caught by earlier groups
+      patterns:
+        - "*"
+
+- package-ecosystem: "pip"
+  # Disabled: this is managed in update-pinned-dependencies.yml
+  directory: "repo/install"
+  open-pull-requests-limit: 0
+  schedule:
+    interval: "weekly"
+
 
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,32 @@ on:
 permissions: {}
 
 jobs:
-  build-and-test:
+  test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        toxenv: [lint-signer, lint-repo, test-signer, test-repo, test-e2e]
+    env:
+      TOXENV: ${{ matrix.toxenv }}
+
     steps:
     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: "3.11"
+        python-version: '3.12'
         cache: 'pip'
-        cache-dependency-path: "**/pyproject.toml"
+        cache-dependency-path: |
+          signer/pyproject.toml
+          repo/pyproject.toml
+          repo/install/requirements.txt
+          build-constraints.txt
 
     - name: Install system dependencies for e2e test
+      if: matrix.toxenv == 'test-e2e'
       run: |
         sudo apt-get install libfaketime softhsm2
         echo "PYKCS11LIB=/usr/lib/softhsm/libsofthsm2.so" >> $GITHUB_ENV
@@ -29,11 +41,5 @@ jobs:
     - name: Install tox
       run: python -m pip install -c build-constraints.txt tox
 
-    - name: Lint
-      run: tox -m lint
-
-    - name: Repository unit tests
-      run: tox -e test-repo
-
-    - name: End-to-end tests
-      run: tox -e test-e2e
+    - name: ${{ matrix.toxenv }}
+      run: tox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install build dependencies
         run: python3 -m pip install -c build-constraints.txt build

--- a/.github/workflows/update-pinned-deps.yml
+++ b/.github/workflows/update-pinned-deps.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
-          python-version: "3.11"
+          python-version: '3.12'
 
       - name: Install pip-tools
         run: pip install -c build-constraints.txt pip-tools


### PR DESCRIPTION
* Bump all python versions to 3.12
* Run tests in a matrix: this should look a lot nicer in GitHub
* Include "test-signer" that was missing so far
* Update the dependency file list for caching
* Add missing init file for tests
* Change dependabot settings