### PR TITLE
dependabot: Bring back individual configs for signer/repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,22 +20,14 @@ updates:
         - "tox"
 
 - package-ecosystem: "pip"
-  directory: "signer"
+  directories:
+    - "/signer"
+    - "/repo"
   schedule:
     interval: "weekly"
   groups:
     pyproject-dependencies:
-      # Dependency ranges set in pyproject.toml
-      patterns:
-        - "*"
-
-- package-ecosystem: "pip"
-  directory: "repo"
-  schedule:
-    interval: "weekly"
-  groups:
-    pyproject-dependencies:
-      # Dependency ranges set in pyproject.toml
+      # Dependency ranges set in {signer,repo}/pyproject.toml
       patterns:
         - "*"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,24 @@ updates:
         - "mypy"
         - "ruff"
         - "tox"
+
+- package-ecosystem: "pip"
+  directory: "signer"
+  schedule:
+    interval: "weekly"
+  groups:
     pyproject-dependencies:
-      # Dependency ranges set in signer & repo pyproject.toml. Also any new
-      # dependencies not caught by earlier groups
+      # Dependency ranges set in pyproject.toml
+      patterns:
+        - "*"
+
+- package-ecosystem: "pip"
+  directory: "repo"
+  schedule:
+    interval: "weekly"
+  groups:
+    pyproject-dependencies:
+      # Dependency ranges set in pyproject.toml
       patterns:
         - "*"
 


### PR DESCRIPTION
It seems like *.txt files are found anywhere under the configured dependabot dir but pyproject.toml are found only in the configured dir itself.

Add separate configs to get updates to pyproject.tomls.
