### PR TITLE
workflows: Add info to dependency update PR

### DIFF
--- a/.github/workflows/update-pinned-deps.yml
+++ b/.github/workflows/update-pinned-deps.yml
@@ -69,6 +69,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "actions: Update pinned requirements",
+              body: "Note: close and reopen the PR to trigger CI.",
               head: process.env.BRANCH,
               base: "main",
             })


### PR DESCRIPTION
The dependency update PR created in a custom workflow does not trigger tests: 
* this is because events do not trigger for PRs opened by GitHub actions default token
* WorkflowDispatch() would run the tests... but would not add the checkmark

Maintainers can workaround this issue with close+reopen: document that in the issue
