### PR TITLE
actions: Add custom message template to update-issue

### DIFF
--- a/actions/update-issue/action.yml
+++ b/actions/update-issue/action.yml
@@ -19,6 +19,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
     - name: Update issue
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       env:
@@ -26,7 +28,7 @@ runs:
       with:
         github-token: ${{ inputs.token }}
         script: |
-          var path = require("path")
+          const fs = require('fs')
 
           success = (process.env.SUCCESS == "true")
 
@@ -53,19 +55,22 @@ runs:
             body = `### Workflow run succeeded for ${context.workflow}.\n` +
                    `Successful run: ${run_url}\n\n` +
                    `Closing issue based on this success.`
-          } else if (issue_number){
-            body = `### Workflow run failed for ${context.workflow}.\n` +
-                   `Failed run: ${run_url}\n\n`
           } else {
             body = `### Workflow run failed for ${context.workflow}.\n` +
-                   `Failed run: ${run_url}\n\n` +
-                   "* Maintainers can re-run the failing job manually\n" +
-                   "* This issue will be automatically closed if a later run succeeds"
+                   `Failed run: ${run_url}\n\n`
           }
 
           // open, comment on, and close issue as needed
           if (!success && !issue_number) {
             console.log("update-issue: Opening a new issue on failure")
+            try {
+              body += fs.readFileSync(`.github/TUF_ON_CI_TEMPLATE/failure.md`).toString()
+            } catch(err) {
+              if (err.code != 'ENOENT') {
+                console.log(err)
+              }
+            }
+
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/docs/REPOSITORY-MAINTENANCE.md
+++ b/docs/REPOSITORY-MAINTENANCE.md
@@ -104,6 +104,13 @@ Supported ways to configure and modify tuf-on-ci workflows:
   see [ONLINE-SIGNING-SETUP.md](ONLINE-SIGNING-SETUP.md) for details
 * A custom GitHub token can be optionally configured with _Repository Secret_
   `TUF_ON_CI_TOKEN`, see details below
+* Workflow failure messages can be configured with `.github/TUF_ON_CI_TEMPLATE/failure.md`:
+  Contents of this file will be included in issues that are opened if workflows fail. This is
+  useful to e.g. notify the maintenance team with @-mentions.
+* Signing pull request templates can be configured with
+  `.github/PULL_REQUEST_TEMPLATE/signing_event.md`. Contents of this file will be included in
+  the pull request message when non-maintainer signers contribute to signing events. This is
+  useful to e.g. notify the maintenance team with @-mentions.
 * The `publish` workflow can be customized to publish to a destination that is not
   the default GitHub Pages
 


### PR DESCRIPTION
This should allow user repositories to include custom content in failure messages -- this is useful in order to
* include maintainer team handle in the message to get notifications
* include advice on process, like a link to a playbook

This could be further specialized so that online-sign failure gets a different message than test failure, but for now it's just a single template.

Also:
* Remove unused path module
* Remove process advice from standard failure message (projects can now include what they want)