### PR TITLE
actions: Guess a better artifact url

### DIFF
--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -77,7 +77,7 @@ runs:
           METADATA_URL="https://${OWNER}.github.io/${REPO}/metadata/"
         fi
         if [ -z $ARTIFACT_URL ]; then
-          ARTIFACT_URL=${METADATA_URL%metadata/}targets/
+          ARTIFACT_URL=${METADATA_URL%/metadata/}/targets/
         fi
 
         if [ -z $UPDATE_BASE_URL ]; then


### PR DESCRIPTION
If artifact URL is not given to test-repository, make a slightly better guess than before. This does something reasonable for both
* the default tuf-on-ci setup
* and the sigstore setup (where targets url is "inside" metadata url)

Previously the latter might end up with
   ARTIFACT_URL="https://tuf-repo-cdn.sigstore.devtargets"
when the METADATA_URL does not end in a slash

Fixes #274 