### PR TITLE
signer: Make sure initial keyid is spec-compliant

### DIFF
--- a/signer/test/test_signer_repository.py
+++ b/signer/test/test_signer_repository.py
@@ -1,6 +1,12 @@
 import unittest
 
-from tuf_on_ci_sign._signer_repository import SignerRepository, build_paths
+from securesystemslib.signer import SSlibKey
+
+from tuf_on_ci_sign._signer_repository import (
+    SignerRepository,
+    build_paths,
+    set_key_field,
+)
 
 
 class TestUser(unittest.TestCase):
@@ -11,6 +17,15 @@ class TestUser(unittest.TestCase):
         self.assertEqual(
             paths, ["myrole/*", "myrole/*/*", "myrole/*/*/*", "myrole/*/*/*/*"]
         )
+
+    def test_set_key_field(self):
+        """Test that set_key_field() modifies the keyid as defined in specification"""
+        key = SSlibKey("abcd", "ed25519", "ed25519", {"public": "abcde"})
+        expected_id = "3e5e819246b51532a5533efb5d7c3e18ca8e7a7f4d2267644c3e2298ac81de18"
+
+        self.assertEqual(key.keyid, "abcd")
+        set_key_field(key, "keyowner", "@testuser")
+        self.assertEqual(key.keyid, expected_id)
 
 
 if __name__ == "__main__":

--- a/signer/tuf_on_ci_sign/delegate.py
+++ b/signer/tuf_on_ci_sign/delegate.py
@@ -33,6 +33,7 @@ from tuf_on_ci_sign._signer_repository import (
     OnlineConfig,
     SignerRepository,
     SignerState,
+    set_key_field,
 )
 from tuf_on_ci_sign._user import User
 
@@ -127,7 +128,7 @@ def _sigstore_import(pull_remote: str) -> Key:
     key = SigstoreKey(
         "abcd", "sigstore-oidc", "Fulcio", {"issuer": issuer, "identity": id}
     )
-    key.unrecognized_fields["x-tuf-on-ci-online-uri"] = "sigstore:"
+    set_key_field(key, "online-uri", "sigstore:")
     return key
 
 
@@ -201,7 +202,7 @@ def _collect_online_key(user_config: User) -> Key:
             key_id = _collect_string("Enter a Google Cloud KMS key id")
             try:
                 uri, key = GCPSigner.import_(key_id)
-                key.unrecognized_fields["x-tuf-on-ci-online-uri"] = uri
+                set_key_field(key, "online-uri", uri)
                 return key
             except Exception as e:  # noqa: BLE001
                 raise click.ClickException(
@@ -212,7 +213,7 @@ def _collect_online_key(user_config: User) -> Key:
             key_name = _collect_string("Enter key name")
             try:
                 uri, key = AzureSigner.import_(vault_name, key_name)
-                key.unrecognized_fields["x-tuf-on-ci-online-uri"] = uri
+                set_key_field(key, "online-uri", uri)
                 return key
             except Exception as e:  # noqa: BLE001
                 raise click.ClickException(
@@ -223,7 +224,7 @@ def _collect_online_key(user_config: User) -> Key:
             scheme = _collect_key_scheme()
             try:
                 uri, key = AWSSigner.import_(key_id, scheme)
-                key.unrecognized_fields["x-tuf-on-ci-online-uri"] = uri
+                set_key_field(key, "online-uri", uri)
                 return key
             except Exception as e:  # noqa: BLE001
                 raise click.ClickException(f"Failed to read AWS KMS key: {e}") from e

--- a/tests/expected/basic/metadata/1.root.json
+++ b/tests/expected/basic/metadata/1.root.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],
@@ -10,7 +10,7 @@
   "consistent_snapshot": true,
   "expires": "2022-02-03T01:02:03Z",
   "keys": {
-   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+   "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
@@ -30,7 +30,7 @@
   "roles": {
    "root": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },
@@ -44,7 +44,7 @@
    },
    "targets": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },

--- a/tests/expected/basic/metadata/1.targets.json
+++ b/tests/expected/basic/metadata/1.targets.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],

--- a/tests/expected/delegated/metadata/1.delegated.json
+++ b/tests/expected/delegated/metadata/1.delegated.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],

--- a/tests/expected/delegated/metadata/1.root.json
+++ b/tests/expected/delegated/metadata/1.root.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],
@@ -10,7 +10,7 @@
   "consistent_snapshot": true,
   "expires": "2022-02-03T01:02:03Z",
   "keys": {
-   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+   "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
@@ -30,7 +30,7 @@
   "roles": {
    "root": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },
@@ -44,7 +44,7 @@
    },
    "targets": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },

--- a/tests/expected/delegated/metadata/2.targets.json
+++ b/tests/expected/delegated/metadata/2.targets.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],
@@ -9,7 +9,7 @@
   "_type": "targets",
   "delegations": {
    "keys": {
-    "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+    "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
      "keytype": "ecdsa",
      "keyval": {
       "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
@@ -21,7 +21,7 @@
    "roles": [
     {
      "keyids": [
-      "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+      "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
      ],
      "name": "delegated",
      "paths": [

--- a/tests/expected/multi-user-signing/metadata/1.root.json
+++ b/tests/expected/multi-user-signing/metadata/1.root.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],
@@ -10,7 +10,7 @@
   "consistent_snapshot": true,
   "expires": "2022-02-03T01:02:03Z",
   "keys": {
-   "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198": {
+   "75e88b2799fee265db824ad603f1c76fe14281d6a449dafdcc8e517036dccd46": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+jBdFHGUlKUilRL3/ReI6whKNbCZk8CL\nJFGVf5JypwD/2lr7d/6owMGuqd9ocCVVHw2GsuGRS7aCQfEvEsTgal6y2NC2gGpi\n1rsv2TGRzxKeZ7m0yX4h/vXlfJe7xys9\n-----END PUBLIC KEY-----\n"
@@ -18,7 +18,7 @@
     "scheme": "ecdsa-sha2-nistp384",
     "x-tuf-on-ci-keyowner": "@tuf-on-ci-user2"
    },
-   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+   "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
@@ -38,7 +38,7 @@
   "roles": {
    "root": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },
@@ -52,8 +52,8 @@
    },
    "targets": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
-     "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
+     "75e88b2799fee265db824ad603f1c76fe14281d6a449dafdcc8e517036dccd46"
     ],
     "threshold": 2
    },

--- a/tests/expected/multi-user-signing/metadata/1.targets.json
+++ b/tests/expected/multi-user-signing/metadata/1.targets.json
@@ -1,11 +1,11 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   },
   {
-   "keyid": "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198",
+   "keyid": "75e88b2799fee265db824ad603f1c76fe14281d6a449dafdcc8e517036dccd46",
    "sig": "XXX"
   }
  ],

--- a/tests/expected/multi-user-signing/metadata/2.root.json
+++ b/tests/expected/multi-user-signing/metadata/2.root.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],
@@ -10,7 +10,7 @@
   "consistent_snapshot": true,
   "expires": "2022-02-03T01:02:03Z",
   "keys": {
-   "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198": {
+   "75e88b2799fee265db824ad603f1c76fe14281d6a449dafdcc8e517036dccd46": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+jBdFHGUlKUilRL3/ReI6whKNbCZk8CL\nJFGVf5JypwD/2lr7d/6owMGuqd9ocCVVHw2GsuGRS7aCQfEvEsTgal6y2NC2gGpi\n1rsv2TGRzxKeZ7m0yX4h/vXlfJe7xys9\n-----END PUBLIC KEY-----\n"
@@ -18,7 +18,7 @@
     "scheme": "ecdsa-sha2-nistp384",
     "x-tuf-on-ci-keyowner": "@tuf-on-ci-user2"
    },
-   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+   "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
@@ -38,7 +38,7 @@
   "roles": {
    "root": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },
@@ -52,8 +52,8 @@
    },
    "targets": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
-     "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
+     "75e88b2799fee265db824ad603f1c76fe14281d6a449dafdcc8e517036dccd46"
     ],
     "threshold": 2
    },

--- a/tests/expected/online-version-bump/metadata/1.root.json
+++ b/tests/expected/online-version-bump/metadata/1.root.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],
@@ -10,7 +10,7 @@
   "consistent_snapshot": true,
   "expires": "2022-02-03T01:02:03Z",
   "keys": {
-   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+   "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
@@ -30,7 +30,7 @@
   "roles": {
    "root": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },
@@ -44,7 +44,7 @@
    },
    "targets": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },

--- a/tests/expected/online-version-bump/metadata/1.targets.json
+++ b/tests/expected/online-version-bump/metadata/1.targets.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],

--- a/tests/expected/root-key-rotation/metadata/1.root.json
+++ b/tests/expected/root-key-rotation/metadata/1.root.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],
@@ -10,7 +10,7 @@
   "consistent_snapshot": true,
   "expires": "2022-02-03T01:02:03Z",
   "keys": {
-   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+   "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
@@ -30,7 +30,7 @@
   "roles": {
    "root": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },
@@ -44,7 +44,7 @@
    },
    "targets": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },

--- a/tests/expected/root-key-rotation/metadata/1.targets.json
+++ b/tests/expected/root-key-rotation/metadata/1.targets.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],

--- a/tests/expected/root-key-rotation/metadata/2.root.json
+++ b/tests/expected/root-key-rotation/metadata/2.root.json
@@ -1,11 +1,11 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   },
   {
-   "keyid": "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198",
+   "keyid": "75e88b2799fee265db824ad603f1c76fe14281d6a449dafdcc8e517036dccd46",
    "sig": "XXX"
   }
  ],
@@ -14,7 +14,7 @@
   "consistent_snapshot": true,
   "expires": "2022-02-03T01:02:03Z",
   "keys": {
-   "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198": {
+   "75e88b2799fee265db824ad603f1c76fe14281d6a449dafdcc8e517036dccd46": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+jBdFHGUlKUilRL3/ReI6whKNbCZk8CL\nJFGVf5JypwD/2lr7d/6owMGuqd9ocCVVHw2GsuGRS7aCQfEvEsTgal6y2NC2gGpi\n1rsv2TGRzxKeZ7m0yX4h/vXlfJe7xys9\n-----END PUBLIC KEY-----\n"
@@ -22,7 +22,7 @@
     "scheme": "ecdsa-sha2-nistp384",
     "x-tuf-on-ci-keyowner": "@tuf-on-ci-user2"
    },
-   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+   "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
@@ -42,7 +42,7 @@
   "roles": {
    "root": {
     "keyids": [
-     "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198"
+     "75e88b2799fee265db824ad603f1c76fe14281d6a449dafdcc8e517036dccd46"
     ],
     "threshold": 1
    },
@@ -56,7 +56,7 @@
    },
    "targets": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },

--- a/tests/expected/target-file-changes/metadata/1.root.json
+++ b/tests/expected/target-file-changes/metadata/1.root.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],
@@ -10,7 +10,7 @@
   "consistent_snapshot": true,
   "expires": "2022-02-03T01:02:03Z",
   "keys": {
-   "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198": {
+   "75e88b2799fee265db824ad603f1c76fe14281d6a449dafdcc8e517036dccd46": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+jBdFHGUlKUilRL3/ReI6whKNbCZk8CL\nJFGVf5JypwD/2lr7d/6owMGuqd9ocCVVHw2GsuGRS7aCQfEvEsTgal6y2NC2gGpi\n1rsv2TGRzxKeZ7m0yX4h/vXlfJe7xys9\n-----END PUBLIC KEY-----\n"
@@ -18,7 +18,7 @@
     "scheme": "ecdsa-sha2-nistp384",
     "x-tuf-on-ci-keyowner": "@tuf-on-ci-user2"
    },
-   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+   "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
@@ -38,7 +38,7 @@
   "roles": {
    "root": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },
@@ -52,8 +52,8 @@
    },
    "targets": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
-     "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
+     "75e88b2799fee265db824ad603f1c76fe14281d6a449dafdcc8e517036dccd46"
     ],
     "threshold": 2
    },

--- a/tests/expected/target-file-changes/metadata/3.targets.json
+++ b/tests/expected/target-file-changes/metadata/3.targets.json
@@ -1,11 +1,11 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   },
   {
-   "keyid": "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198",
+   "keyid": "75e88b2799fee265db824ad603f1c76fe14281d6a449dafdcc8e517036dccd46",
    "sig": "XXX"
   }
  ],

--- a/tests/expected/target-files-in-delegated-roles/metadata/1.root.json
+++ b/tests/expected/target-files-in-delegated-roles/metadata/1.root.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],
@@ -10,7 +10,7 @@
   "consistent_snapshot": true,
   "expires": "2022-02-03T01:02:03Z",
   "keys": {
-   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+   "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
     "keytype": "ecdsa",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
@@ -30,7 +30,7 @@
   "roles": {
    "root": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },
@@ -44,7 +44,7 @@
    },
    "targets": {
     "keyids": [
-     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
     ],
     "threshold": 1
    },

--- a/tests/expected/target-files-in-delegated-roles/metadata/1.targets.json
+++ b/tests/expected/target-files-in-delegated-roles/metadata/1.targets.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],
@@ -9,7 +9,7 @@
   "_type": "targets",
   "delegations": {
    "keys": {
-    "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+    "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
      "keytype": "ecdsa",
      "keyval": {
       "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
@@ -21,7 +21,7 @@
    "roles": [
     {
      "keyids": [
-      "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+      "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
      ],
      "name": "delegated",
      "paths": [

--- a/tests/expected/target-files-in-delegated-roles/metadata/2.delegated.json
+++ b/tests/expected/target-files-in-delegated-roles/metadata/2.delegated.json
@@ -1,7 +1,7 @@
 {
  "signatures": [
   {
-   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
    "sig": "XXX"
   }
  ],


### PR DESCRIPTION
Spec demands that keyids be calculated from the keys canonicalized json. This is not that useful and it is a bit of a pain in the butt so most clients don't bother... but it is in the spec.

Make sure the keyids we generate are compliant.