### PR TITLE
Use dependabot beta features

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,33 +31,13 @@ updates:
   schedule:
     interval: "weekly"
 
-
 - package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
-    time: "10:25"
-
-- package-ecosystem: "github-actions"
-  directory: "actions/create-signing-events/"
-  schedule:
-    interval: "daily"
-    time: "10:25"
-
-- package-ecosystem: "github-actions"
-  directory: "actions/online-sign/"
-  schedule:
-    interval: "daily"
-    time: "10:25"
-
-- package-ecosystem: "github-actions"
-  directory: "actions/signing-event/"
-  schedule:
-    interval: "daily"
-    time: "10:25"
-
-- package-ecosystem: "github-actions"
-  directory: "actions/upload-repository/"
+  directories:
+    - "/"
+    - "/actions/create-signing-events/"
+    - "/actions/online-sign/"
+    - "/actions/signing-event/"
+    - "/actions/upload-repository/"
   schedule:
     interval: "daily"
     time: "10:25"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,11 +32,13 @@ updates:
     interval: "weekly"
 
 - package-ecosystem: "github-actions"
-  directories:
+  directories:  
     - "/"
     - "/actions/create-signing-events/"
     - "/actions/online-sign/"
     - "/actions/signing-event/"
+    - "/actions/test-repository/"
+    - "/actions/update-issue/"
     - "/actions/upload-repository/"
   schedule:
     interval: "daily"


### PR DESCRIPTION
This is a public beta feature that should help with dependabot spam for the actions by combining all actions (and workflows) updates into one issue

https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/

--- 

I'd like to try the beta since they're asking for feedback. We should see if it's working immediately as I'm also adding the last two actions so that will trigger some updates...