### PR TITLE
dependabot: Reorder pip entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,13 @@ updates:
         - "tox"
 
 - package-ecosystem: "pip"
+  # Disabled: this is managed in update-pinned-dependencies.yml
+  directory: "/repo/install"
+  open-pull-requests-limit: 0
+  schedule:
+    interval: "weekly"
+
+- package-ecosystem: "pip"
   directories:
     - "/signer"
     - "/repo"
@@ -30,13 +37,6 @@ updates:
       # Dependency ranges set in {signer,repo}/pyproject.toml
       patterns:
         - "*"
-
-- package-ecosystem: "pip"
-  # Disabled: this is managed in update-pinned-dependencies.yml
-  directory: "repo/install"
-  open-pull-requests-limit: 0
-  schedule:
-    interval: "weekly"
 
 - package-ecosystem: "github-actions"
   directories:  


### PR DESCRIPTION
The aim is to get dependabot to actually skip /repo/install/ because this is managed by update-pinned-deps.yml: Currently the pyproject-dependencies group will catch these deps as well and we don't want that.

If this does not work, we'll have to move the pinning file out of /repo/ completely.