### PR TITLE
dependabot: Group the actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,3 +50,7 @@ updates:
   schedule:
     interval: "daily"
     time: "10:25"
+  groups:
+    actions-dependencies:
+      patterns:
+        - "*"


### PR DESCRIPTION
At least currently Dependabots new "directories" feature only creates one issue at a time (even if it should file multiple). I hope this grouping will at least include all of the changes in a single PR.