### PR TITLE
Upgrade tuf dependency

### DIFF
--- a/repo/pyproject.toml
+++ b/repo/pyproject.toml
@@ -12,7 +12,7 @@ description = "TUF-on-CI repository tools, intended to be executed on a CI syste
 readme = "README.md"
 dependencies = [
   "securesystemslib[awskms, azurekms, gcpkms, sigstore, pynacl] ~= 0.31.0",
-  "tuf ~= 3.0",
+  "tuf ~= 3.1",
   "click ~= 8.1",
 ]
 requires-python = ">=3.10"

--- a/signer/pyproject.toml
+++ b/signer/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "packaging >= 23.2,< 25.0",
   "platformdirs ~= 4.2",
   "securesystemslib[awskms,azurekms,gcpkms,hsm,sigstore] ~= 0.31.0",
-  "tuf ~= 3.0",
+  "tuf ~= 3.1",
   "click ~= 8.1",
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
* signer already accidentally uses 3.1 API: upgrade both repo and signer
* Don't upgrade further because tuf 4-5 are incompatible with released sigstore

Fixes #300