### PR TITLE
Fix noncompliant keyids

### DIFF
--- a/signer/tuf_on_ci_sign/import_repo.py
+++ b/signer/tuf_on_ci_sign/import_repo.py
@@ -162,6 +162,7 @@ def import_repo(verbose: int, push: bool, event_name: str, import_file: str | No
                     ok = _update_keys(root.keys, role_data) and ok
                     if not ok:
                         raise AbortEdit("Missing values")
+
             else:
                 with repo.edit_targets(rolename) as targets:
                     ok = _update_expiry(targets, role_data) and ok
@@ -171,6 +172,10 @@ def import_repo(verbose: int, push: bool, event_name: str, import_file: str | No
                         ok = _update_keys(targets.delegations.keys, role_data) and ok
                     if not ok:
                         raise AbortEdit("Missing values")
+
+        # we have updated keys defined in root/targets: make sure keyids are compliant
+        repo.force_compliant_keyids("root")
+        repo.force_compliant_keyids("targets")
 
         if not ok:
             print("Error: Undefined values found. please save this in a file,")


### PR DESCRIPTION
Fixes #336 , relates to #292 

This change will ensure that a a keyid fix can be done in a single signing event

* Make sure signing works with multiple keys (the UI for identifying which key is used isn't there yet but that's ok since so far this will only be used for the non-compliant keyid fix where the actual signing key is the same one, just with two different keyids)
* Add a hidden `--force-compliant-keyids` flag to delegate: this will update all keyids in the role and will mark all affected delegations to be resigned

This approach (just switching the all keyids) looks surprising but  should be 100% spec compliant. Example:
* root v1 has one root signer with key A using non-compliant keyid _abcd_. The metadata signatures contains a sig from _abcd_
* `tuf-on-ci-delegate --force-compliant-keyids sign/fix-keyids root` is used: the signing event now contains a root v2 with one root signer with key A using valid keyid _efgh_ (same key, different keyid)
* the signer runs `tuf-on-ci-sign sign/fix-keyids` as usual: this signs twice with A; The metadata signatures now contain a sig from _abcd_ and a sig from _efgh_
* when client see root v2 they will ensure it is signed by old signers (_abcd_) and new signers (_efgh_). The fact that this happens to be the same key should not be an issue (since the keys are part of two different threshold calculations)

