### PR TITLE
actions: Fix test-repository source comparison

### DIFF
--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -45,6 +45,7 @@ runs:
       if: inputs.compare_source == 'true'
       with:
         ref: "publish"
+        path: "source/"
 
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
@@ -93,9 +94,9 @@ runs:
         fi
 
         if [ "$COMPARE_SOURCE" = "true" ]; then
-          COMPARE_SOURCE_ARG="--compare-source"
+          COMPARE_SOURCE_ARG="--compare-source source/metadata"
         else
-          COMPARE_SOURCE_ARG="--no-compare-source"
+          COMPARE_SOURCE_ARG=""
         fi
 
         if [ $VALID_DAYS -eq 0 ]; then

--- a/repo/tuf_on_ci/client.py
+++ b/repo/tuf_on_ci/client.py
@@ -34,7 +34,7 @@ def expiry_check(dir: str, role: str, timestamp: int):
 @click.option("-u", "--update-base-url", type=str)
 @click.option("-r", "--initial-root", type=str)
 @click.option("-e", "--expected-artifact", type=str)
-@click.option("--compare-source/--no-compare-source", default=True)
+@click.option("-c", "--compare-source", type=str)
 @click.option("-t", "--time", type=int)
 @click.option("-o", "--offline-time", type=int)
 @click.option("-d", "--metadata-dir", type=str)
@@ -45,7 +45,7 @@ def client(
     update_base_url: str | None,
     initial_root: str | None,
     expected_artifact: str | None,
-    compare_source: bool,
+    compare_source: str | None,
     time: int | None,
     offline_time: int | None,
     metadata_dir: str | None,
@@ -101,7 +101,7 @@ def client(
             # Compare received metadata versions with source metadata
             for f in ["root.json", "timestamp.json"]:
                 client_file = os.path.join(metadata_dir, f)
-                source_file = os.path.join("metadata", f)
+                source_file = os.path.join(compare_source, f)
                 if not cmp(source_file, client_file, shallow=False):
                     sys.exit(f"Error: metadata does not match sources: {f} failed")
             print("Client metadata matches sources: OK")


### PR DESCRIPTION
Previously setting the initial root would only work if compare_source was False (because compare_source would lead to a checkout that would clean the initial root.json that had been put into working dir).

* Change tuf-on-ci-test-client so that --compare-source has an argument (the metadata directory to compare against)
* Checkout into a subdirectory: this allows root.json to exist in workdir
* Pass the metadata directory to tuf-on-ci-test-client --compare-source

This changes tuf-on-ci-test-client CLI but does not change the action API so existing users are fine.

Fixes #345