### PR TITLE
repo: Handle root correctly in create-signing-events

### DIFF
--- a/repo/tuf_on_ci/create_signing_events.py
+++ b/repo/tuf_on_ci/create_signing_events.py
@@ -54,7 +54,12 @@ def create_signing_events(verbose: int, push: bool) -> None:
         msg = f"Periodic version bump: {rolename} v{version}"
         event = f"sign/{rolename}-v{version}"
         ref = f"refs/remotes/origin/{event}" if push else f"refs/heads/{event}"
-        _git(["commit", "-m", msg, "--signoff", "--", f"metadata/{rolename}.json"])
+        files = [f"metadata/{rolename}.json"]
+        if rolename == "root":
+            files.append(f"metadata/root_history/{version}.root.json")
+
+        _git(["add", "--", *files])
+        _git(["commit", "-m", msg, "--signoff"])
         try:
             _git(["show-ref", "--quiet", "--verify", ref])
             logging.debug("Signing event branch %s already exists", event)

--- a/tests/expected/signing-event-creation/metadata/1.root.json
+++ b/tests/expected/signing-event-creation/metadata/1.root.json
@@ -1,0 +1,65 @@
+{
+ "signatures": [
+  {
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": true,
+  "expires": "2021-02-10T01:02:03Z",
+  "keys": {
+   "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp384",
+    "x-tuf-on-ci-keyowner": "@tuf-on-ci-user1"
+   },
+   "fa47289": {
+    "keytype": "ed25519",
+    "keyval": {
+     "public": "fa472895c9756c2b9bcd1440bf867d0fa5c4edee79e9792fa9822be3dd6fcbb3"
+    },
+    "scheme": "ed25519",
+    "x-tuf-on-ci-online-uri": "envvar:LOCAL_TESTING_KEY"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
+    ],
+    "threshold": 1
+   },
+   "snapshot": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 7,
+    "x-tuf-on-ci-signing-period": 6
+   },
+   "targets": {
+    "keyids": [
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
+    ],
+    "threshold": 1
+   },
+   "timestamp": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 2,
+    "x-tuf-on-ci-signing-period": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 1,
+  "x-tuf-on-ci-expiry-period": 7,
+  "x-tuf-on-ci-signing-period": 6
+ }
+}

--- a/tests/expected/signing-event-creation/metadata/2.root.json
+++ b/tests/expected/signing-event-creation/metadata/2.root.json
@@ -1,0 +1,65 @@
+{
+ "signatures": [
+  {
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": true,
+  "expires": "2021-02-12T01:02:03Z",
+  "keys": {
+   "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp384",
+    "x-tuf-on-ci-keyowner": "@tuf-on-ci-user1"
+   },
+   "fa47289": {
+    "keytype": "ed25519",
+    "keyval": {
+     "public": "fa472895c9756c2b9bcd1440bf867d0fa5c4edee79e9792fa9822be3dd6fcbb3"
+    },
+    "scheme": "ed25519",
+    "x-tuf-on-ci-online-uri": "envvar:LOCAL_TESTING_KEY"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
+    ],
+    "threshold": 1
+   },
+   "snapshot": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 7,
+    "x-tuf-on-ci-signing-period": 6
+   },
+   "targets": {
+    "keyids": [
+     "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460"
+    ],
+    "threshold": 1
+   },
+   "timestamp": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 2,
+    "x-tuf-on-ci-signing-period": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 2,
+  "x-tuf-on-ci-expiry-period": 7,
+  "x-tuf-on-ci-signing-period": 6
+ }
+}

--- a/tests/expected/signing-event-creation/metadata/2.targets.json
+++ b/tests/expected/signing-event-creation/metadata/2.targets.json
@@ -1,0 +1,17 @@
+{
+ "signatures": [
+  {
+   "keyid": "ddadf0c54d24c3429a36b7ad8434414fa35b80922497d2c99067261d38746460",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "targets",
+  "expires": "2021-02-12T01:02:03Z",
+  "spec_version": "1.0.31",
+  "targets": {},
+  "version": 2,
+  "x-tuf-on-ci-expiry-period": 7,
+  "x-tuf-on-ci-signing-period": 6
+ }
+}

--- a/tests/expected/signing-event-creation/metadata/3.snapshot.json
+++ b/tests/expected/signing-event-creation/metadata/3.snapshot.json
@@ -1,0 +1,19 @@
+{
+ "signatures": [
+  {
+   "keyid": "fa47289",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "snapshot",
+  "expires": "2021-02-12T01:02:03Z",
+  "meta": {
+   "targets.json": {
+    "version": 2
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 3
+ }
+}

--- a/tests/expected/signing-event-creation/metadata/timestamp.json
+++ b/tests/expected/signing-event-creation/metadata/timestamp.json
@@ -1,0 +1,19 @@
+{
+ "signatures": [
+  {
+   "keyid": "fa47289",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "timestamp",
+  "expires": "2021-02-07T01:02:03Z",
+  "meta": {
+   "snapshot.json": {
+    "version": 3
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 3
+ }
+}


### PR DESCRIPTION
The versioned file in `metadata/root_history/` should get created when root.json is modified.

Also add a end to end test for create-signing-events.

Fixes #347