### PR TITLE
repo: Use html inside markdown to get relative links

### DIFF
--- a/repo/tuf_on_ci/build_repository.py
+++ b/repo/tuf_on_ci/build_repository.py
@@ -67,7 +67,7 @@ def build_description(repo: CIRepository) -> str:
         signing_days, _ = repo.signing_expiry_period(rolename)
         signing = expiry - timedelta(days=signing_days)
 
-        name_str = f"{rolename} (<a href=\"{json_link}\">json</a>)"
+        name_str = f'{rolename} (<a href="{json_link}">json</a>)'
         date_str = f"[Starts {signing.strftime('%Y-%m-%d')}](## '{signing} - {expiry}')"
         threshold_str = f"{role.threshold} of {len(signers)}"
         signer_str = f"{', '.join(signers)} ({threshold_str} required)"

--- a/repo/tuf_on_ci/build_repository.py
+++ b/repo/tuf_on_ci/build_repository.py
@@ -67,7 +67,7 @@ def build_description(repo: CIRepository) -> str:
         signing_days, _ = repo.signing_expiry_period(rolename)
         signing = expiry - timedelta(days=signing_days)
 
-        name_str = f"{rolename} ([json]({json_link}))"
+        name_str = f"{rolename} (<a href=\"{json_link}\">json</a>)"
         date_str = f"[Starts {signing.strftime('%Y-%m-%d')}](## '{signing} - {expiry}')"
         threshold_str = f"{role.threshold} of {len(signers)}"
         signer_str = f"{', '.join(signers)} ({threshold_str} required)"


### PR DESCRIPTION
Hopefully this link will stay relative so it works even when hosted outside GitHub Pages. Based on https://jku.github.io/tuf-on-ci-sigstore-test/metadata/ this is the case: Jekyll does not rewrite this to absolute links

Unfortunately the css link is still absolute but not fully qualified so the page will be unstyled when copied outside GitHub pages: but at least the links now work

Fixes #353