### PR TITLE
Increase the number of root rotations allowed during TUF refresh.

### DIFF
--- a/repo/tuf_on_ci/client.py
+++ b/repo/tuf_on_ci/client.py
@@ -77,11 +77,9 @@ def client(
 
         if update_base_url is not None:
             # Update client to update_base_url before doing the actual update
-            updater = Updater(metadata_dir,
-                              update_base_url,
-                              artifact_dir,
-                              artifact_url,
-                              config=config)
+            updater = Updater(
+                metadata_dir, update_base_url, artifact_dir, artifact_url, config=config
+            )
             try:
                 updater.refresh()
                 print(f"Client metadata update from base url {update_base_url}: OK")
@@ -89,11 +87,9 @@ def client(
                 print(f"WARNING: update base url has expired metadata: {e}")
 
         # Update client to metadata_url
-        updater = Updater(metadata_dir,
-                          metadata_url,
-                          artifact_dir,
-                          artifact_url,
-                          config=config)
+        updater = Updater(
+            metadata_dir, metadata_url, artifact_dir, artifact_url, config=config
+        )
         ref_time_string = ""
         if time is not None:
             # HACK: replace reference time with ours: initial root has been loaded

--- a/repo/tuf_on_ci/client.py
+++ b/repo/tuf_on_ci/client.py
@@ -81,7 +81,10 @@ def client(
                 print(f"WARNING: update base url has expired metadata: {e}")
 
         # Update client to metadata_url
-        updater = Updater(metadata_dir, metadata_url, artifact_dir, artifact_url)
+        # Allow for a large number of root rotations, as metadata is
+        # not cached during testing
+        config = UpdaterConfig(max_root_rotations=256)
+        updater = Updater(metadata_dir, metadata_url, artifact_dir, artifact_url, config=config)
         ref_time_string = ""
         if time is not None:
             # HACK: replace reference time with ours: initial root has been loaded


### PR DESCRIPTION
The default value of 32 is too low for some TUF repositories.