### PR TITLE
Added support for delegations using cloud KMS

### DIFF
--- a/actions/online-sign-targets/action.yml
+++ b/actions/online-sign-targets/action.yml
@@ -103,7 +103,7 @@ runs:
     - name: Dispatch another signing event workflow
       # dispatch if using default token: otherwise update_targets step
       # has alreaddy triggered a push event
-      if: inputs.token == github.token && steps.update_targets.outputs.targets_signed == 'true'
+      if: inputs.token == github.token && steps.sign_targets.outputs.targets_signed == 'true'
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         github-token: ${{ inputs.token }}

--- a/actions/online-sign-targets/action.yml
+++ b/actions/online-sign-targets/action.yml
@@ -1,25 +1,47 @@
-name: 'Signing event'
-description: 'TUF-on-CI Signing event management'
+name: 'Online signing of targets'
+description: 'TUF-on-CI Online signer for targets'
 
-# This action is called from signing-event workflow, which is dispatched in multiple ways
-# depending on the type of token provided in inputs.
-#
-# 1. create-signing-events action creates a new signing event branch
-#     * When using a custom token this triggers push event handler
-#     * When using the default GitHub token the action calls createWorkflowDispatch()
-# 2. A signer pushes artifact changes to a signing event branch
-#     * This triggers push event handler
-# 3. This action (signing-event) makes a metadata change in update_targets step as a result of an artifact change
-#     * When using a custom token this triggers push event handler
-#     * When using the default GitHub token the action calls createWorkflowDispatch()
-#
-# Cases 1 & 3 lead to status step running. Case 2 leads to skipping status step, but
-# triggering case 3 immediately afterwards.
+# This action is not called from any standard workflows.
+# To use this, create custom workflow that triggers this action when
+# needed. This is typically done for delegations, that would be
+# triggered based on a change to the delegation metadata file.
 
 inputs:
   token:
     description: 'GitHub token'
     required: true
+  targets_to_sign:
+    description: "whitespace separated list of targets role names that should be signed with KMS"
+    required: false
+    default: ""
+  gcp_workload_identity_provider:
+    description: "Google Cloud workload identity provider (required if GCP is used to sign targets roles)"
+    required: false
+    default: ""
+  gcp_service_account:
+    description: "Google Cloud service account name (required if GCP is used to sign targets roles)"
+    required: false
+    default: ""
+  aws_region:
+    description: "AWS region"
+    required: false
+    default: ""
+  aws_role_to_assume:
+    description: "AWS role to assume"
+    required: false
+    default: ""
+  azure_client_id:
+    description: "Azure SPN client id (required to use Azure to sign target roles)"
+    required: false
+    default: ""
+  azure_tenant_id:
+    description: "Azure SPN tenant id (required to use Azure to sign target roles)"
+    required: false
+    default: ""
+  azure_subscription_id:
+    description: "Azure SPN subscription id (required to use Azure to sign target roles)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -28,6 +50,29 @@ runs:
       with:
         token: ${{ inputs.token }}
         fetch-depth: 0
+
+    - name: Authenticate to Google Cloud
+      if: inputs.gcp_workload_identity_provider != ''
+      uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
+      with:
+        token_format: access_token
+        workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+        service_account: ${{ inputs.gcp_service_account }}
+
+    - name: Authenticate to AWS
+      if: inputs.aws_role_to_assume != ''
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4.0.2
+      with:
+        aws-region: ${{ inputs.aws_region }}
+        role-to-assume: ${{ inputs.aws_role_to_assume }}
+
+    - name: Authenticate to Azure cloud
+      if: inputs.azure_client_id != ''
+      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a # v2.1.1
+      with:
+        client-id: ${{ inputs.azure_client_id }}
+        tenant-id: ${{ inputs.azure_tenant_id }}
+        subscription-id: ${{ inputs.azure_subscription_id }}
 
     - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:
@@ -40,20 +85,23 @@ runs:
         echo "::endgroup::"
       shell: bash
 
-    - id: update_targets
+    - id: sign_targets
+      if: inputs.targets_to_sign != ''
+      env:
+        TARGETS_TO_SIGN: ${{ inputs.targets_to_sign }}
       run: |
-        if tuf-on-ci-update-targets >> update-output;  then
-          echo "targets_updated=true" >> $GITHUB_OUTPUT
+        if tuf-on-ci-online-sign-targets $TARGETS_TO_SIGN >> sign-output;  then
+          echo "targets_signed=true" >> $GITHUB_OUTPUT
         else
-          echo "targets_updated=false" >> $GITHUB_OUTPUT
+          echo "targets_signed=false" >> $GITHUB_OUTPUT
         fi
-        cat update-output
-        cat update-output >> output
-        cat update-output >> "$GITHUB_STEP_SUMMARY"
+        cat sign-output
+        cat sign-output >> output
+        cat sign-output >> "$GITHUB_STEP_SUMMARY"
       shell: bash
 
     - id: status
-      if: steps.update_targets.outputs.targets_updated != 'true'
+      if: steps.update_targets.outputs.targets_updated != 'true' && steps.sign_targets.outputs.targets_signed != 'true'
       run: |
         if tuf-on-ci-status >> status-output;  then
           echo "status=success" >> $GITHUB_OUTPUT
@@ -143,19 +191,3 @@ runs:
           }
 
           await core.summary.addHeading(summary).write()
-
-    - name: Dispatch another signing event workflow
-      # dispatch if using default token: otherwise update_targets step
-      # has alreaddy triggered a push event
-      if: inputs.token == github.token && steps.update_targets.outputs.targets_updated == 'true'
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-      with:
-        github-token: ${{ inputs.token }}
-        script: |
-          console.log('Dispatching another signing event workflow after a targets metadata update')
-          github.rest.actions.createWorkflowDispatch({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            workflow_id: 'signing-event.yml',
-            ref: process.env.GITHUB_REF_NAME,
-          })

--- a/actions/online-sign-targets/action.yml
+++ b/actions/online-sign-targets/action.yml
@@ -100,94 +100,18 @@ runs:
         cat sign-output >> "$GITHUB_STEP_SUMMARY"
       shell: bash
 
-    - id: status
-      if: steps.update_targets.outputs.targets_updated != 'true' && steps.sign_targets.outputs.targets_signed != 'true'
-      run: |
-        if tuf-on-ci-status >> status-output;  then
-          echo "status=success" >> $GITHUB_OUTPUT
-        else
-          echo "status=failure" >> $GITHUB_OUTPUT
-        fi
-        cat status-output
-        cat status-output >> output
-        cat status-output >> "$GITHUB_STEP_SUMMARY"
-      shell: bash
-
-    - id: update-pr
+    - name: Dispatch another signing event workflow
+      # dispatch if using default token: otherwise update_targets step
+      # has alreaddy triggered a push event
+      if: inputs.token == github.token && steps.update_targets.outputs.targets_updated == 'true'
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-      env:
-        STATUS: ${{ steps.status.outputs.status }}
       with:
         github-token: ${{ inputs.token }}
         script: |
-          const fs = require('fs')
-          const title = `Signing event: ${process.env.GITHUB_REF_NAME}`
-          const repo = `${context.repo.owner}/${context.repo.repo}`
-          const prs = await github.rest.search.issuesAndPullRequests({
-            q: `in:title+"${title}"+state:open+type:pr+repo:${repo}`
-          })
-
-          if (prs.data.total_count > 1) {
-            core.setFailed("Found more than one open pull request with same title")
-          } else if (prs.data.total_count == 0) {
-            const response = await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: title,
-              body: `Processing signing event ${process.env.GITHUB_REF_NAME}, please wait.`,
-              draft: true,
-              head: process.env.GITHUB_REF_NAME,
-              base: "main",
-            })
-            pr = response.data.number
-            console.log(`Created pull request #${pr}`)
-          } else {
-            pr = prs.data.items[0].number
-            console.log(`Found existing pull request #${pr}`)
-          }
-
-          message = fs.readFileSync('./output').toString()
-          summary = "Signing event in progress"
-          should_be_draft = true
-          if (process.env.STATUS == 'success') {
-            message += "### Signing event is successful\n\n"
-            message += "Threshold of signatures has been reached: this signing event can be reviewed and merged."
-            summary = "Signing event is successful"
-            should_be_draft = false
-          }
-
-          // Pull request numbers are also valid issue numbers
-          github.rest.issues.createComment({
+          console.log('Dispatching another signing event workflow after a targets metadata update')
+          github.rest.actions.createWorkflowDispatch({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            issue_number: pr,
-            body: message,
+            workflow_id: 'signing-event.yml',
+            ref: process.env.GITHUB_REF_NAME,
           })
-
-          // Following pile of GraphQL is here because draft state cannot
-          // be modified through rest API at all!
-
-          // First get the PR "Id" and current draft state...
-          response = await github.graphql(`query {
-            repository(owner: "${context.repo.owner}", name: "${context.repo.repo}") {
-              pullRequest(number: ${pr}) { id, isDraft }
-            }
-          }`)
-          pr_id = response.repository.pullRequest.id
-          is_draft = response.repository.pullRequest.isDraft
-          // Then modify PR if needed
-          if (should_be_draft && !is_draft) {
-            await github.graphql(`mutation SetPullRequestDraft {
-              convertPullRequestToDraft(input: {pullRequestId: "${pr_id}"}) {
-                pullRequest { isDraft }
-              }
-            }`)
-          } else if (!should_be_draft && is_draft) {
-            await github.graphql(`mutation SetPullRequestReady {
-              markPullRequestReadyForReview(input: {pullRequestId: "${pr_id}"}) {
-                pullRequest { isDraft }
-              }
-            }`)
-          }
-
-          await core.summary.addHeading(summary).write()

--- a/actions/online-sign-targets/action.yml
+++ b/actions/online-sign-targets/action.yml
@@ -103,7 +103,7 @@ runs:
     - name: Dispatch another signing event workflow
       # dispatch if using default token: otherwise update_targets step
       # has alreaddy triggered a push event
-      if: inputs.token == github.token && steps.update_targets.outputs.targets_updated == 'true'
+      if: inputs.token == github.token && steps.update_targets.outputs.targets_signed == 'true'
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         github-token: ${{ inputs.token }}

--- a/actions/online-sign/action.yml
+++ b/actions/online-sign/action.yml
@@ -21,6 +21,18 @@ inputs:
     description: "AWS role to assume"
     required: false
     default: ""
+  azure_client_id:
+    description: "Azure SPN client id (required to use Azure to sign target roles)"
+    required: false
+    default: ""
+  azure_tenant_id:
+    description: "Azure SPN tenant id (required to use Azure to sign target roles)"
+    required: false
+    default: ""
+  azure_subscription_id:
+    description: "Azure SPN subscription id (required to use Azure to sign target roles)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -44,6 +56,14 @@ runs:
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.aws_role_to_assume }}
+
+    - name: Authenticate to Azure cloud
+      if: inputs.azure_client_id != ''
+      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a # v2.1.1
+      with:
+        client-id: ${{ inputs.azure_client_id }}
+        tenant-id: ${{ inputs.azure_tenant_id }}
+        subscription-id: ${{ inputs.azure_subscription_id }}
 
     - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -68,6 +68,7 @@ runs:
           echo "targets_updated=false" >> $GITHUB_OUTPUT
         fi
         cat update-output
+        cat update-output >> output
         cat update-output >> "$GITHUB_STEP_SUMMARY"
       shell: bash
 
@@ -82,6 +83,7 @@ runs:
           echo "targets_signed=false" >> $GITHUB_OUTPUT
         fi
         cat sign-output
+        cat sign-output >> output
         cat sign-output >> "$GITHUB_STEP_SUMMARY"
       shell: bash
 
@@ -94,6 +96,7 @@ runs:
           echo "status=failure" >> $GITHUB_OUTPUT
         fi
         cat status-output
+        cat status-output >> output
         cat status-output >> "$GITHUB_STEP_SUMMARY"
       shell: bash
 
@@ -130,7 +133,7 @@ runs:
             console.log(`Found existing pull request #${pr}`)
           }
 
-          message = fs.readFileSync('./status-output').toString()
+          message = fs.readFileSync('./output').toString()
           summary = "Signing event in progress"
           should_be_draft = true
           if (process.env.STATUS == 'success') {

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -20,6 +20,10 @@ inputs:
   token:
     description: 'GitHub token'
     required: true
+  targets_to_sign:
+    description: "whitespace separated list of targets role names that should be signed with KMS"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -42,17 +46,31 @@ runs:
 
     - id: update_targets
       run: |
-        if tuf-on-ci-update-targets >> status-output;  then
+        if tuf-on-ci-update-targets >> update-output;  then
           echo "targets_updated=true" >> $GITHUB_OUTPUT
         else
           echo "targets_updated=false" >> $GITHUB_OUTPUT
         fi
-        cat status-output
-        cat status-output >> "$GITHUB_STEP_SUMMARY"
+        cat update-output
+        cat update-output >> "$GITHUB_STEP_SUMMARY"
+      shell: bash
+
+    - id: sign_targets
+      if: inputs.targets_to_sign != ""
+      env:
+        TARGETS_TO_SIGN: ${{ inputs.targets_to_sign }}
+      run: |
+        if tuf-on-ci-online-sign-targets $TARGETS_TO_SIGN >> sign-output;  then
+          echo "targets_signed=true" >> $GITHUB_OUTPUT
+        else
+          echo "targets_signed=false" >> $GITHUB_OUTPUT
+        fi
+        cat sign-output
+        cat sign-output >> "$GITHUB_STEP_SUMMARY"
       shell: bash
 
     - id: status
-      if: steps.update_targets.outputs.targets_updated != 'true'
+      if: steps.update_targets.outputs.targets_updated != 'true' && steps.sign_targets.outputs.targets_signed != 'true'
       run: |
         if tuf-on-ci-status >> status-output;  then
           echo "status=success" >> $GITHUB_OUTPUT
@@ -143,8 +161,8 @@ runs:
           await core.summary.addHeading(summary).write()
 
     - name: Dispatch another signing event workflow
-      # dispatch if using default token: otherwise update_targets step has already triggered a push event
-      if: inputs.token == github.token && steps.update_targets.outputs.targets_updated == 'true'
+      # dispatch if using default token: otherwise update_targets or sign_targets step has already pushed and triggered a push event
+      if: inputs.token == github.token && (steps.update_targets.outputs.targets_updated == 'true' || steps.sign_targets.outputs.targets_signed == 'true')
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         github-token: ${{ inputs.token }}

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -24,6 +24,14 @@ inputs:
     description: "whitespace separated list of targets role names that should be signed with KMS"
     required: false
     default: ""
+  gcp_workload_identity_provider:
+    description: "Google Cloud workload identity provider (required if GCP is used to sign targets roles)"
+    required: false
+    default: ""
+  gcp_service_account:
+    description: "Google Cloud service account name (required if GCP is used to sign targets roles)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -32,6 +40,14 @@ runs:
       with:
         token: ${{ inputs.token }}
         fetch-depth: 0
+
+    - name: Authenticate to Google Cloud
+      if: inputs.gcp_workload_identity_provider != ''
+      uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
+      with:
+        token_format: access_token
+        workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+        service_account: ${{ inputs.gcp_service_account }}
 
     - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -56,7 +56,7 @@ runs:
       shell: bash
 
     - id: sign_targets
-      if: inputs.targets_to_sign != ""
+      if: inputs.targets_to_sign != ''
       env:
         TARGETS_TO_SIGN: ${{ inputs.targets_to_sign }}
       run: |

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -32,6 +32,26 @@ inputs:
     description: "Google Cloud service account name (required if GCP is used to sign targets roles)"
     required: false
     default: ""
+  aws_region:
+    description: "AWS region"
+    required: false
+    default: ""
+  aws_role_to_assume:
+    description: "AWS role to assume"
+    required: false
+    default: ""
+  azure_client_id:
+    description: "Azure SPN client id (required to use Azure to sign target roles)"
+    required: false
+    default: ""
+  azure_tenant_id:
+    description: "Azure SPN tenant id (required to use Azure to sign target roles)"
+    required: false
+    default: ""
+  azure_subscription_id:
+    description: "Azure SPN subscription id (required to use Azure to sign target roles)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -48,6 +68,21 @@ runs:
         token_format: access_token
         workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
         service_account: ${{ inputs.gcp_service_account }}
+
+    - name: Authenticate to AWS
+      if: inputs.aws_role_to_assume != ''
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4.0.2
+      with:
+        aws-region: ${{ inputs.aws_region }}
+        role-to-assume: ${{ inputs.aws_role_to_assume }}
+
+    - name: Authenticate to Azure cloud
+      if: inputs.azure_client_id != ''
+      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a # v2.1.1
+      with:
+        client-id: ${{ inputs.azure_client_id }}
+        tenant-id: ${{ inputs.azure_tenant_id }}
+        subscription-id: ${{ inputs.azure_subscription_id }}
 
     - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:

--- a/docs/DELEGATION-MANUAL.md
+++ b/docs/DELEGATION-MANUAL.md
@@ -1,0 +1,114 @@
+# TUF-on-CI Online Delegations Manual
+
+> [!WARNING]
+> This functionality is still experimental. Changes in the API and
+> behaviour may happen in future releases.
+
+TUF-on-CI now supports "online" delegations, which refers to a
+delegator using an "online" key, such as a cloud KMS.
+
+The difference is that now there is an action that can be called to
+have TUF-on-CI automatically sign updated metadata files.
+
+The option to use an online signer is given when a role is
+modified. When configuring a role the cli now provides this choice:
+
+```
+Enter name of role to modify: targets
+Modifying delegation for targets
+
+Configuring role targets
+ 1. Configure signers: [@-test-user-1], requiring 1 signatures
+ 2. Configure expiry: Role expires in 365 days, re-signing starts 60 days before expiry
+Please choose an option or press enter to continue: 1
+Choose what keytype to use:
+1. Configure offline signers:
+2. Configure online signers
+```
+
+If online signers is selected, configuration similar to when
+configuring the online role (snapshot and timestamp) is required.
+
+## Limitations
+
+This feature is still experimental, and also there are some known issues
+
+* **Dispatching of delegation workflows**: Due to GitHub's limitation
+  on GitHub Action invocation based on changes made by the default
+  GitHub Action token, automated signing may be required to be
+  dispatched manually.
+
+  A solution to this can be to use a different token, such as a PAT or
+  an OAuth application.
+
+* **Number of signers**: Currently only a single online signer can be
+  configured for a delegation. This also means that there can not be a
+  combination of offline and online signers. As online keys are mostly
+  used for automated signing, this limitation should not impose any
+  practical problems.
+
+## Use cases
+
+This could be used when a deployment wants to programatically add
+content (targets) to a TUF repository, and rely on automated
+signing. The operator of the repository would still need to provide
+some custom automation, such as how to modify the repository and push
+the changes, how to approve pull requests and so on.
+
+## Operation
+
+To automate signing, the primary API is the [online sign targets
+action](actions/online-sign-targets/action.yml). In the default
+configuration, this action is not used and so must explicitly be
+called.
+
+The preferred method is to create a GitHub Actions job that is run
+when one or more metadata files for delegations are modified. This
+example shows how changes to `foo-delegation` can be signed
+automatically. This Example uses Azure KMS, but GCP and AWS KMSes are
+also supported.
+
+```yml
+name: Foo Delegate Signing
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ['sign/**']
+    paths:
+      - metadata/foo-delegate.json
+jobs:
+  sign-and-push:
+    name: TUF-on-CI Foo Delegate sign
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for making commits in signing event and for modifying draft state
+      pull-requests: write # for modifying signing event pull requests
+      actions: write # for dispatching another signing-event workflow
+    steps:
+
+      - name: Sign delegation
+        uses: theupdateframework/tuf-on-ci/actions/online-sign-targets@main
+        with:
+          azure_client_id: secrets.AZURE_CLIENT_ID
+          azure_tenant_id: secrets.AZURE_TENANT_ID
+          azure_subscription_id: secrets.AZURE_SUBSCRIPTION_ID
+          targets_to_sign: foo-delegate
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
+```
+
+The steps to work with automated delegation signing would thus be:
+
+1. A signing event ( e.g. `sign/update-foo-target`) branch is created
+   and pushed
+1. TUF-on-CI creates a signing event PR
+1. TUF-on-CI detects changed targets and updates delegation metadata
+   and commits the changes
+1. Automated signing detects changes to delegation metadata and signs
+   it, and commits the changes
+1. TUF-on-CI moves signing event PR from draft to ready for review
+
+The PR can then be reviewed as normal and merged when ready as for any
+signing event.

--- a/repo/pyproject.toml
+++ b/repo/pyproject.toml
@@ -23,6 +23,7 @@ tuf-on-ci-build-repository = "tuf_on_ci:build_repository"
 tuf-on-ci-test-client = "tuf_on_ci:client"
 tuf-on-ci-create-signing-events = "tuf_on_ci:create_signing_events"
 tuf-on-ci-online-sign = "tuf_on_ci:online_sign"
+tuf-on-ci-online-sign-targets = "tuf_on_ci:online_sign_targets"
 tuf-on-ci-status = "tuf_on_ci:status"
 tuf-on-ci-update-targets = "tuf_on_ci:update_targets"
 

--- a/repo/tuf_on_ci/__init__.py
+++ b/repo/tuf_on_ci/__init__.py
@@ -3,7 +3,7 @@ from tuf_on_ci.build_repository import build_repository
 from tuf_on_ci.client import client
 from tuf_on_ci.create_signing_events import create_signing_events
 from tuf_on_ci.online_sign import online_sign
-from tuf_on_ci.signing_event import status, update_targets
+from tuf_on_ci.signing_event import online_sign_targets, status, update_targets
 
 __all__ = [
     "__version__",
@@ -11,6 +11,7 @@ __all__ = [
     "client",
     "create_signing_events",
     "online_sign",
+    "online_sign_targets",
     "status",
     "update_targets",
 ]

--- a/repo/tuf_on_ci/_repository.py
+++ b/repo/tuf_on_ci/_repository.py
@@ -43,6 +43,13 @@ TAG_ONLINE_URI = "x-tuf-on-ci-online-uri"
 logger = logging.getLogger(__name__)
 
 
+def get_signer(key: Key) -> str:
+    if TAG_KEYOWNER in key.unrecognized_fields:
+        return key.unrecognized_fields[TAG_KEYOWNER]
+
+    return key.unrecognized_fields[TAG_ONLINE_URI]
+
+
 @unique
 class State(Enum):
     ADDED = (0,)
@@ -489,7 +496,7 @@ class CIRepository(Repository):
 
         # Build lists of signed signers and not signed signers
         for key in self._get_keys(rolename, known_good):
-            keyowner = key.unrecognized_fields[TAG_KEYOWNER]
+            keyowner = get_signer(key)
             try:
                 payload = CanonicalJSONSerializer().serialize(md.signed)
                 key.verify_signature(md.signatures[key.keyid], payload)

--- a/repo/tuf_on_ci/online_sign.py
+++ b/repo/tuf_on_ci/online_sign.py
@@ -29,13 +29,10 @@ def _git(cmd: list[str]) -> subprocess.CompletedProcess:
 @click.command()  # type: ignore[arg-type]
 @click.option("-v", "--verbose", count=True, default=0)
 @click.option("--push/--no-push", default=False)
-@click.option("--role", default="")
-def online_sign(verbose: int, push: bool, role: str) -> None:
+def online_sign(verbose: int, push: bool) -> None:
     """Update The TUF snapshot and timestamp if needed
 
-    If role is provided, that role is updated instead.
-
-    Create a commit with the updated role changes (if any).
+    Create a commit with the snapshot and timestamp changes (if any).
     If --push, the commit is pushed to origin.
 
     A new snapshot will be created if
@@ -47,38 +44,21 @@ def online_sign(verbose: int, push: bool, role: str) -> None:
     * A new snapshot was created
     * or timestamp is in signing period
     * or timestamp is currently not correctly signed
-
-    Provided role will be updated if
-    * Content is changed
-    * or role is in signing period
-    * or role is currently not correctly signed
     """
 
     logging.basicConfig(level=logging.WARNING - verbose * 10)
     repo = CIRepository("metadata")
-    signed = False
+    valid_snapshot = repo.is_signed("snapshot")
+    snapshot_updated, _ = repo.do_snapshot(not valid_snapshot)
+    valid_timestamp = repo.is_signed("timestamp")
+    timestamp_updated, _ = repo.do_timestamp(not valid_timestamp)
 
-    if role != "":
-        repo.sign(role)
-        # Exception is raised if nothing is signed
-        signed = True
-        roles = role
-        files = [repo._get_filename(role)]
-    else:
-        valid_snapshot = repo.is_signed("snapshot")
-        snapshot_updated, _ = repo.do_snapshot(not valid_snapshot)
-        valid_timestamp = repo.is_signed("timestamp")
-        timestamp_updated, _ = repo.do_timestamp(not valid_timestamp)
+    if timestamp_updated:
         roles = "snapshot & timestamp" if snapshot_updated else "timestamp"
-        signed = timestamp_updated
-        files = ["metadata/timestamp.json", "metadata/snapshot.json"]
-    if signed:
         msg = f"Online sign ({roles})"
 
         click.echo(msg)
-        cmd = ["add"]
-        cmd.extend(files)
-        _git(cmd)
+        _git(["add", "metadata/timestamp.json", "metadata/snapshot.json"])
         _git(["commit", "-m", msg, "--signoff"])
         if push:
             _git(["push", "origin", "HEAD"])

--- a/repo/tuf_on_ci/online_sign.py
+++ b/repo/tuf_on_ci/online_sign.py
@@ -48,10 +48,10 @@ def online_sign(verbose: int, push: bool) -> None:
 
     logging.basicConfig(level=logging.WARNING - verbose * 10)
     repo = CIRepository("metadata")
-    valid_snapshot = repo.is_signed("snapshot")
-    snapshot_updated, _ = repo.do_snapshot(not valid_snapshot)
-    valid_timestamp = repo.is_signed("timestamp")
-    timestamp_updated, _ = repo.do_timestamp(not valid_timestamp)
+    valid_s = repo.is_signed("snapshot") and not repo.is_in_signing_period("snapshot")
+    snapshot_updated, _ = repo.do_snapshot(not valid_s)
+    valid_t = repo.is_signed("timestamp") and not repo.is_in_signing_period("timestamp")
+    timestamp_updated, _ = repo.do_timestamp(not valid_t)
 
     if timestamp_updated:
         roles = "snapshot & timestamp" if snapshot_updated else "timestamp"

--- a/repo/tuf_on_ci/online_sign.py
+++ b/repo/tuf_on_ci/online_sign.py
@@ -60,7 +60,7 @@ def online_sign(verbose: int, push: bool, role: str) -> None:
 
     if role != "":
         repo.sign(role)
-        # Execptionn is raised if nothing is signed
+        # Exception is raised if nothing is signed
         signed = True
         roles = role
         files = [repo._get_filename(role)]

--- a/signer/tuf_on_ci_sign/_signer_repository.py
+++ b/signer/tuf_on_ci_sign/_signer_repository.py
@@ -794,12 +794,9 @@ class SignerRepository(Repository):
         signing_keys: dict[str, Key] = {}
         for key in self._get_keys(rolename):
             # Detect if the key is an online key
-            if TAG_ONLINE_URI in key.unrecognized_fields:
+            keyowner = key.unrecognized_fields[TAG_KEYOWNER]
+            if keyowner == self.user.name:
                 signing_keys[key.keyid] = key
-            else:
-                keyowner = key.unrecognized_fields[TAG_KEYOWNER]
-                if keyowner == self.user.name:
-                    signing_keys[key.keyid] = key
 
         if rolename == "root":
             # special case for import: if the same key was used with different keyid

--- a/signer/tuf_on_ci_sign/_signer_repository.py
+++ b/signer/tuf_on_ci_sign/_signer_repository.py
@@ -721,7 +721,6 @@ class SignerRepository(Repository):
             else:
                 old_role = old_delegations[name]
                 old_signers = []
-
                 for key in self._get_keys(name, known_good=True):
                     old_signers.append(_get_signer_name(key))
 

--- a/signer/tuf_on_ci_sign/_signer_repository.py
+++ b/signer/tuf_on_ci_sign/_signer_repository.py
@@ -381,7 +381,7 @@ class SignerRepository(Repository):
             md.signatures[key.keyid] = Signature(key.keyid, "")
 
             # Mark role as unsigned if user is a signer (and there are no open invites)
-            keyowner = key.unrecognized_fields[TAG_KEYOWNER]
+            keyowner = key.unrecognized_fields.get(TAG_KEYOWNER)
             if keyowner == self.user.name and not open_invites:
                 self.unsigned.add(role)
 

--- a/signer/tuf_on_ci_sign/_signer_repository.py
+++ b/signer/tuf_on_ci_sign/_signer_repository.py
@@ -793,7 +793,6 @@ class SignerRepository(Repository):
         md = self.open(rolename)
         signing_keys: dict[str, Key] = {}
         for key in self._get_keys(rolename):
-            # Detect if the key is an online key
             keyowner = key.unrecognized_fields[TAG_KEYOWNER]
             if keyowner == self.user.name:
                 signing_keys[key.keyid] = key

--- a/signer/tuf_on_ci_sign/delegate.py
+++ b/signer/tuf_on_ci_sign/delegate.py
@@ -92,8 +92,8 @@ def _get_offline_input(
         if choice == 0:
             break
         if choice == 1:
-            # if role is not root or targets, allow online keys
-            if role in ["root", "targets"]:
+            # if role is not root, allow online keys
+            if role in ["root"]:
                 config.signers = click.prompt(
                     bold(f"Please enter list of {role} signers"),
                     default=", ".join(config.signers),

--- a/signer/tuf_on_ci_sign/delegate.py
+++ b/signer/tuf_on_ci_sign/delegate.py
@@ -40,6 +40,8 @@ from tuf_on_ci_sign._user import User
 # sigstore is not a supported key by default
 KEY_FOR_TYPE_AND_SCHEME[("sigstore-oidc", "Fulcio")] = SigstoreKey
 
+TAG_KEYOWNER = "x-tuf-on-ci-keyowner"
+TAG_ONLINE_URI = "x-tuf-on-ci-online-uri"
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +49,7 @@ logger = logging.getLogger(__name__)
 def _get_offline_input(
     role: str,
     config: OfflineConfig,
-) -> OfflineConfig:
+) -> tuple[OfflineConfig, Key]:
     config = copy.deepcopy(config)
     click.echo(f"\nConfiguring role {role}")
     username_re = re.compile("^\\@[0-9a-zA-Z\\-]+$")
@@ -71,6 +73,7 @@ def _get_offline_input(
 
         return signers
 
+    online_key = None
     while True:
         click.echo(
             f" 1. Configure signers: [{', '.join(config.signers)}], "
@@ -89,11 +92,35 @@ def _get_offline_input(
         if choice == 0:
             break
         if choice == 1:
-            config.signers = click.prompt(
-                bold(f"Please enter list of {role} signers"),
-                default=", ".join(config.signers),
-                value_proc=verify_signers,
-            )
+            # if role is not root or targets, allow online keys
+            if role in ["root", "targets"]:
+                config.signers = click.prompt(
+                    bold(f"Please enter list of {role} signers"),
+                    default=", ".join(config.signers),
+                    value_proc=verify_signers,
+                )
+            else:
+                click.echo("Choose what keytype to use:")
+                click.echo("1. Configure offline signers:")
+                click.echo("2. Configure online signers")
+                signer_choice = click.prompt(
+                    bold("Please choose an option or press enter to continue"),
+                    type=click.IntRange(1, 2),
+                )
+
+                if signer_choice == 1:
+                    config.signers = click.prompt(
+                        bold(f"Please enter list of {role} signers"),
+                        default=", ".join(config.signers),
+                        value_proc=verify_signers,
+                    )
+                elif signer_choice == 2:
+                    toplevel = git_expect(["rev-parse", "--show-toplevel"])
+                    settings_path = os.path.join(toplevel, ".tuf-on-ci-sign.ini")
+                    user_config = User(settings_path)
+                    online_key = _collect_online_key(user_config)
+                    uri = online_key.unrecognized_fields[TAG_ONLINE_URI]
+                    config.signers = [uri]
 
             if len(config.signers) == 1:
                 config.threshold = 1
@@ -116,7 +143,7 @@ def _get_offline_input(
                 default=config.signing_period,
             )
 
-    return config
+    return (config, online_key)
 
 
 def _sigstore_import(pull_remote: str) -> Key:
@@ -136,7 +163,7 @@ def _get_online_input(config: OnlineConfig, user_config: User) -> OnlineConfig:
     config = copy.deepcopy(config)
     click.echo("\nConfiguring online roles")
     while True:
-        keyuri = config.key.unrecognized_fields["x-tuf-on-ci-online-uri"]
+        keyuri = config.key.unrecognized_fields[TAG_ONLINE_URI]
         click.echo(f" 1. Configure online key: {keyuri}")
         click.echo(
             f" 2. Configure timestamp: Expires in {config.timestamp_expiry} days,"
@@ -238,7 +265,7 @@ def _collect_online_key(user_config: User) -> Key:
                 "ed25519",
                 "ed25519",
                 {"public": pub_key},
-                {"x-tuf-on-ci-online-uri": uri},
+                {TAG_ONLINE_URI: uri},
             )
 
 
@@ -275,10 +302,10 @@ def _collect_key_scheme() -> str:
 def _init_repository(repo: SignerRepository) -> bool:
     click.echo("Creating a new TUF-on-CI repository")
 
-    root_config = _get_offline_input(
+    root_config, _ = _get_offline_input(
         "root", OfflineConfig([repo.user.name], 1, 365, 60)
     )
-    targets_config = _get_offline_input("targets", deepcopy(root_config))
+    targets_config, _ = _get_offline_input("targets", deepcopy(root_config))
 
     # As default we offer sigstore online key(s)
     keys = _sigstore_import(repo.user.pull_remote)
@@ -314,21 +341,25 @@ def _update_online_roles(repo: SignerRepository) -> bool:
 
 def _update_offline_role(repo: SignerRepository, role: str) -> bool:
     config = repo.get_role_config(role)
+    online_key = None
     if not config:
         # Non existent role
         click.echo(f"Creating a new delegation for {role}")
-        new_config = _get_offline_input(
+        new_config, online_key = _get_offline_input(
             role, OfflineConfig([repo.user.name], 1, 365, 60)
         )
     else:
         click.echo(f"Modifying delegation for {role}")
-        new_config = _get_offline_input(role, config)
+        new_config, online_key = _get_offline_input(role, config)
         if new_config == config:
             return False
 
     key = None
-    if repo.user.name in new_config.signers:
-        key = get_signing_key_input()
+    if online_key is None:
+        if repo.user.name in new_config.signers:
+            key = get_signing_key_input()
+    else:
+        key = online_key
 
     repo.set_role_config(role, new_config, key)
     return True

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -287,6 +287,7 @@ signer_init_multiuser()
     INPUT=(
         ""                  # Configure root? [enter to continue]
         "1"                 # Configure targets? [1: configure signers]
+        "1"                 # Chose offline signer
         "@tuf-on-ci-user1, @tuf-on-ci-user2" # Enter signers
         "2"                 # Enter threshold
         ""                  # Configure targets? [enter to continue]

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -160,6 +160,7 @@ signer_add_delegation()
     INPUT=(
         "delegated"         # select role to modify
         "1"                 # Configure role delegated? [1: configure signers]
+        "1"                 # Chose offline signer
         ""                  # Enter list of signers [Enter to accept default of @user1]
         ""                  # Configure sole delegated? [enter to continue]
         "2"                 # Choose signing key [2: yubikey]


### PR DESCRIPTION
This is mainly done by modifying tuf-on-ci-delegate to accept an online key as a signer for delegations. This require some extra care when dealing with the signer's identity. Keyowner or online-uri is now used.

Tuf-on-ci-online-sign now supports an extra parameter --role. This is used to perform online signing with delegations.

Closes https://github.com/theupdateframework/tuf-on-ci/issues/75