### PR TITLE
signer: Accept username without @ in config file

### DIFF
--- a/signer/test/test_user.py
+++ b/signer/test/test_user.py
@@ -25,6 +25,14 @@ push-remote = origin
 pull-remote = myremote
 """
 
+NAME_WITH_NO_PREFIX = """
+[settings]
+pykcs11lib = /usr/lib/x86_64-linux-gnu/libykcs11.so
+user-name = signer
+push-remote = origin
+pull-remote = myremote
+"""
+
 REQUIRED_AND_SIGNING_KEYS = """
 [settings]
 pykcs11lib = /usr/lib/x86_64-linux-gnu/libykcs11.so
@@ -70,6 +78,12 @@ class TestUser(unittest.TestCase):
             self.assertEqual(user.pykcs11lib, "/usr/lib/x86_64-linux-gnu/libykcs11.so")
             self.assertEqual(user.push_remote, "origin")
             self.assertEqual(user.pull_remote, "myremote")
+
+            with open(inifile, "w") as f:
+                f.write(NAME_WITH_NO_PREFIX)
+
+            user2 = User(inifile)
+            self.assertEqual(user.name, user2.name)
 
             with open(inifile, "w") as f:
                 f.write(MISSING_NAME)

--- a/signer/tuf_on_ci_sign/_user.py
+++ b/signer/tuf_on_ci_sign/_user.py
@@ -39,6 +39,8 @@ class User:
             raise click.ClickException(f"Settings file {path} not found")
         try:
             self.name = self._config["settings"]["user-name"]
+            if not self.name.startswith("@"):
+                self.name = f"@{self.name}"
             self.push_remote = self._config["settings"]["push-remote"]
             self.pull_remote = self._config["settings"]["pull-remote"]
         except KeyError as e:


### PR DESCRIPTION
It seems harmless but useful to prefix usernames with @ if the username in configuration does not have the prefix already