### PR TITLE
repo: Add workaround for sigstore KMS keyid

### DIFF
--- a/repo/tuf_on_ci/_repository.py
+++ b/repo/tuf_on_ci/_repository.py
@@ -228,6 +228,15 @@ class CIRepository(Repository):
         for key in self._get_keys(rolename):
             if rolename in ["timestamp", "snapshot"]:
                 uri = key.unrecognized_fields[TAG_ONLINE_URI]
+
+                # FIXME: workaround for issue #422, only needed while sigstore
+                # root-signing online key keyid is incorrect
+                if (
+                    uri
+                    == "gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/timestamp"
+                ):
+                    uri = "gcpkms:projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/timestamp/cryptoKeyVersions/1"  # noqa: E501
+
                 signer = Signer.from_priv_key_uri(uri, key)
                 md.sign(signer, True)
             else:


### PR DESCRIPTION
The sigstore root-signing online key keyid was entered incorrectly: Add a workaround here so there is more time to fix the actual keyid.

Fixes #422

--- 
DRAFT while I am not sure of the actual key version