### PR TITLE
signer: Add a hint to do touch authentication

### DIFF
--- a/signer/tuf_on_ci_sign/_user.py
+++ b/signer/tuf_on_ci_sign/_user.py
@@ -79,12 +79,11 @@ class User:
         """
 
         def get_secret(secret: str) -> str:
-            msg = f"Enter {secret} to sign"
+            msg = f"Enter {secret} to sign (provide touch/bio authentication if needed)"
 
             # special case for tests -- prompt() will lockup trying to hide STDIN:
             if not sys.stdin.isatty():
                 return sys.stdin.readline().rstrip()
-
             return click.prompt(bold(msg), hide_input=True)
 
         if key.keyid in self._signers:


### PR DESCRIPTION
Fixes #417

---

It's not great but best I could think of -- the alternative would be to print that after PIN input but I'm not sure that's better.

FYI @bobcallaway