### PR TITLE
actions: Switch status html rendering to pandoc

### DIFF
--- a/actions/upload-repository/action.yml
+++ b/actions/upload-repository/action.yml
@@ -47,7 +47,7 @@ runs:
       shell: bash
 
     - name: Render repository state in HTML
-      uses: docker://pandoc/core:3.5
+      uses: docker://pandoc/core:3.5.0@sha256:771842ce6f661785e0e12931f82ea64046d70fa48ea5cff480492d79ab3b8ff1
       with:
         args: >-
           --metadata title="TUF Repository state"

--- a/actions/upload-repository/action.yml
+++ b/actions/upload-repository/action.yml
@@ -34,6 +34,7 @@ runs:
         echo "::group::Install tuf-on-ci"
         ROOT=$GITHUB_ACTION_PATH/../..
         pip install -c $ROOT/action-constraints.txt $ROOT/repo/
+        cp $GITHUB_ACTION_PATH/index.css .
         echo "::endgroup::"
       shell: bash
 
@@ -45,27 +46,34 @@ runs:
         find build -type f | xargs ls -lh
       shell: bash
 
-    - uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # 1.0.13
+    - name: Render repository state in HTML
+      uses: docker://pandoc/core:3.5
       with:
-        source: build
-        destination: build-jekyll
+        args: >-
+          --metadata title="TUF Repository state"
+          --variable title=""
+          --standalone
+          --embed-resources
+          --css index.css
+          --output build/${{inputs.metadata_path}}/index.html
+          build/${{inputs.metadata_path}}/index.md
 
     - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
       if: inputs.gh_pages != 'true'
       with:
         name: metadata
-        path: build-jekyll/${{inputs.metadata_path}}/*
+        path: build/${{inputs.metadata_path}}/*
 
     - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
       if: inputs.gh_pages != 'true'
       with:
         name: artifacts
-        path: build-jekyll/${{inputs.artifacts_path}}/*
+        path: build/${{inputs.artifacts_path}}/*
 
     - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
       if: inputs.gh_pages == 'true'
       with:
-        path: build-jekyll/
+        path: build/
 
     - id: status-summary
       shell: bash

--- a/actions/upload-repository/index.css
+++ b/actions/upload-repository/index.css
@@ -1,0 +1,46 @@
+body {
+  color: #24292e;
+  line-height: 1.5;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 16px;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+a {
+  background-color: transparent;
+  color: #0366d6;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+table {
+  margin-bottom: 16px;
+  border-collapse: collapse;
+  border-spacing: 0;
+  display: block;
+  overflow: auto;
+  width: 100%;
+}
+
+table th {
+  font-weight: 600;
+}
+
+table td,
+table th {
+  border: 1px solid #dfe2e5;
+  padding: 6px 13px;
+}
+
+table tr {
+  background-color: #fff;
+  border-top: 1px solid #c6cbd1;
+}
+
+table tr:nth-child(2n) {
+  background-color: #f6f8fa;
+}


### PR DESCRIPTION
We used jekyll before: it has various issues and turned out to not be the right tool for the job -- I only used it since it was a GitHub maintained action.

* Use pandoc (as container step) instead
* Include a minimal CSS file to make the status page look like it's not still the 1980s
* Prepare by copying the css file to workdir (which the pandoc container has access to)
* Two separate build directories are now not needed (everything happens in "build/").
* The result is now full standalone: copying the html file around should break nothing 

Fixes #430.

Example in https://jku.github.io/tuf-demo/metadata/