### PR TITLE
Bump repository and test Python version to 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,18 @@ jobs:
       fail-fast: false
       matrix:
         toxenv: [lint-signer, test-signer]
-        pyversion: ['3.9', '3.12']
+        pyversion: ['3.9', '3.13']
         os: [ubuntu-latest, macos-latest]
-        # Only run repository on 3.12 (dependency pinning is easier with single version)
+        # Only run repository on 3.13 (dependency pinning is easier with single version)
         include:
           - toxenv: lint-repo
-            pyversion: '3.12'
+            pyversion: '3.13'
             os: ubuntu-latest
           - toxenv: test-repo
-            pyversion: '3.12'
+            pyversion: '3.13'
             os: ubuntu-latest
           - toxenv: test-e2e
-            pyversion: '3.12'
+            pyversion: '3.13'
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install build dependencies
         run: python3 -m pip install -c build/build-constraints.txt build

--- a/.github/workflows/update-pinned-deps.yml
+++ b/.github/workflows/update-pinned-deps.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install pip-tools
         run: pip install -c build/build-constraints.txt pip-tools

--- a/actions/create-signing-events/action.yml
+++ b/actions/create-signing-events/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: "3.11"
+        python-version: "3.13"
 
     - run: |
         echo "::group::Install tuf-on-ci"

--- a/actions/online-sign-targets/action.yml
+++ b/actions/online-sign-targets/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:
-        python-version: "3.11"
+        python-version: "3.13"
 
     - run: |
         echo "::group::Install tuf-on-ci"

--- a/actions/online-sign/action.yml
+++ b/actions/online-sign/action.yml
@@ -67,7 +67,7 @@ runs:
 
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: "3.11"
+        python-version: "3.13"
 
     - run: |
         echo "::group::Install tuf-on-ci"

--- a/actions/signing-event/action.yml
+++ b/actions/signing-event/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: "3.11"
+        python-version: "3.13"
 
     - run: |
         echo "::group::Install tuf-on-ci"

--- a/actions/test-repository/action.yml
+++ b/actions/test-repository/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: "3.11"
+        python-version: "3.13"
 
     - run: |
         echo "::group::Install tuf-on-ci"

--- a/actions/upload-repository/action.yml
+++ b/actions/upload-repository/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: "3.11"
+        python-version: "3.13"
 
     - run: |
         echo "::group::Install tuf-on-ci"


### PR DESCRIPTION
This is not urgent in any way but good to do at some point (and doing it right after a release sounds like a good idea):
* Install Python 3.13 in all actions
* Use 3.13 in tests and other workflows (except signer tests where we also want 3.9)