### PR TITLE
signer: Handle the "yubikey auth required" case

### DIFF
--- a/signer/pyproject.toml
+++ b/signer/pyproject.toml
@@ -36,6 +36,7 @@ python_version = "3.9"
 [[tool.mypy.overrides]]
 module = [
   "securesystemslib.*",
+  "PyKCS11.*",
 ]
 ignore_missing_imports = "True"
 


### PR DESCRIPTION
There is now light infrastructure for handling PKCS errors... I'm only handling the one that seems to trip people up since there are so many possible errors: we can't possibly do a good job of handling all of them.

Couple of review notes:
* I can't directly test this one: The touch policy on a yubikey can only be set when the certificate is created and and the touch policy on my keys is the default "never" -- I'd have to overwrite my key or buy a new yubikey for this. I have tested the code by adding handling for another case (CKR_ARGUMENTS_BAD) and that works fine so I trust that this one works too
* I was a little surprised I have to access a private field (`e.__context__`) to get the original exception... but that seems the only way

Fixes #527 