### PR TITLE
workflows: let update-pinned-deps have the token it needs

### DIFF
--- a/.github/workflows/update-pinned-deps.yml
+++ b/.github/workflows/update-pinned-deps.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: false
+          persist-credentials: true # for pushing a new branch later
 
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:


### PR DESCRIPTION
The zizmor lint addition tightened the workflow token leaks: In this specific case we actually want to leak as we are pushing a branch.

It looks like zizmor does not complain about this now that we explicitly set the value to true.