### PR TITLE
Include actions/ in dependabot lint tool update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,14 +15,16 @@ updates:
   directories:
     - "/signer"
     - "/repo"
+    - "/actions"
   schedule:
     interval: "weekly"
   groups:
     pinned-test-dependencies:
-      # Dependencies pinned in {signer,repo}/pyproject.toml to ensure test reproducibility
+      # Dependencies pinned to ensure test reproducibility
       patterns:
         - "mypy"
         - "ruff"
+        - "zizmor"
     minimum-runtime-dependencies:
       # Runtime dependency ranges set in {signer,repo}/pyproject.toml
       patterns:


### PR DESCRIPTION
I didn't add zizmor to repo/pypproject.toml in #548 since it's not actually linting the python code. Instead I put in in actions/lint-requirements.txt. This means we have to include the actions/ repo in the dependendabot config to get the version updates.