### PR TITLE
repo: Fix securesystemslib annotation issue

### DIFF
--- a/repo/tuf_on_ci/_repository.py
+++ b/repo/tuf_on_ci/_repository.py
@@ -365,9 +365,10 @@ class CIRepository(Repository):
                     return False, "Online signing or expiry period failed sanity check"
 
             for key in md.signed.keys.values():
-                data: bytes = encode_canonical(key.to_dict()).encode()
+                canonical_key = encode_canonical(key.to_dict())
+                assert canonical_key
                 hasher = digest("sha256")
-                hasher.update(data)
+                hasher.update(canonical_key.encode())
                 if key.keyid != hasher.hexdigest():
                     return False, f"Key {key.keyid} keyid does not match content hash"
 


### PR DESCRIPTION
This fixes lint: securesystemslib annotations are now better but they also now make it clear the API is a bit bonkers so we need to workaround.

This should unblock the dependabot updates