### PR TITLE
Dependabot: Handle docker dependencies (iow pandoc)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,8 @@ updates:
     actions-dependencies:
       patterns:
         - "*"
+
+- package-ecosystem: "docker"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
pandoc has not been automatically updated and now the used image has disappeared so publish is failing.

Possibly we should also move on from pandoc 3.5 but I'm doing a minimal update to fix the brokenness now.