### PR TITLE
Update pandoc image reference

### DIFF
--- a/actions/upload-repository/action.yml
+++ b/actions/upload-repository/action.yml
@@ -50,7 +50,7 @@ runs:
       shell: bash
 
     - name: Render repository state in HTML
-      uses: docker://pandoc/core:3.5.0@sha256:771842ce6f661785e0e12931f82ea64046d70fa48ea5cff480492d79ab3b8ff1
+      uses: docker://pandoc/core:3.5.0@sha256:befd63aa7c9b795bdf681415e3984aaa2fe20eeed3b5facca494f125f4171218
       with:
         args: >-
           --metadata title="TUF Repository state"


### PR DESCRIPTION
* Dependabot apparently does not manage docker:// references
* The pandoc image has been updated and the old no longer exists

Update hash manually for now to unbreak things: I will file an issue to actually improve this somehow, this is not a reasonable way to update things.