### PR TITLE
Updated the azure documentation for online sign to be correct

### DIFF
--- a/docs/ONLINE-SIGNING-SETUP.md
+++ b/docs/ONLINE-SIGNING-SETUP.md
@@ -36,29 +36,6 @@ currently experimental (and not supported by all TUF client libraries)
 1. Make sure Azure allows this repository OIDC identity to sign with a Key Vault key.
 1. Define `AZURE_CLIENT_ID`, `AZURE_TENANT_ID` and `AZURE_SUBSCRIPTION_ID` as repository
    secrets in _Settings->Secrets and variables->Actions->Secrets_
-1. Modify the online-sign workflow like this:
-    ```yaml
-    jobs:
-        online-sign:
-        runs-on: ubuntu-latest
-
-        permissions:
-            id-token: 'write' # for OIDC identity access
-            contents: 'write' # for committing snapshot/timestamp changes
-            actions: 'write' # for dispatching publish workflow
-
-        steps:
-        ...
-            - name: Login to Azure
-              uses: azure/login@v1
-              with:
-                client-id: ${{ secrets.AZURE_CLIENT_ID }}
-                tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-                subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        ...
-            - id: online-sign
-              uses: theupdateframework/tuf-on-ci/actions/online-sign@main
-    ```
 1. _(only needed for initial configuration)_ Prepare your local environment: Use [az
        login](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
        and authenticate against the environment where the key vault


### PR DESCRIPTION
Closes #768 

The documentation states that the online workflow should be updated with `azure/login`, this is not needed as it's done by the action itself: https://github.com/theupdateframework/tuf-on-ci/blob/abb0e8fa145fe95f74243393d67f427460d5d96d/actions/online-sign/action.yml#L62