### PR TITLE
Added support to disable key id verification.

### DIFF
--- a/repo/test/test_ci_repository.py
+++ b/repo/test/test_ci_repository.py
@@ -1,10 +1,44 @@
 import os
 import shutil
 import unittest
+from copy import deepcopy
 from tempfile import TemporaryDirectory
+from unittest import mock
 
-from tuf_on_ci._repository import CIRepository
+from securesystemslib.formats import encode_canonical
+from securesystemslib.hash import digest
+from tuf.api.metadata import Metadata, Root
+
+from tuf_on_ci._repository import CIRepository, _keyid_matches_content
 from tuf_on_ci.signing_event import _find_changed_target_roles
+
+
+class TestKeyidMatchesContent(unittest.TestCase):
+    def setUp(self):
+        root = Metadata[Root].from_file("test/test_repo1/root.json")
+        # An existing key from the test repo. Its stored keyid does not
+        # match thecontent hash.
+        self.non_matching_key = next(iter(root.signed.keys.values()))
+
+        self.matching_key = deepcopy(self.non_matching_key)
+        hasher = digest("sha256")
+        hasher.update(encode_canonical(self.matching_key.to_dict()).encode())
+        self.matching_key.keyid = hasher.hexdigest()
+
+    def test_matching_keyid_matches(self):
+        self.assertTrue(_keyid_matches_content(self.matching_key))
+
+    def test_non_matching_keyid_does_not_match(self):
+        self.assertFalse(_keyid_matches_content(self.non_matching_key))
+
+    def test_env_var_bypasses_check(self):
+        with mock.patch.dict(os.environ, {"TUF_ON_CI_NO_VERIFY_KID": "1"}):
+            self.assertTrue(_keyid_matches_content(self.matching_key))
+            self.assertTrue(_keyid_matches_content(self.non_matching_key))
+
+    def test_empty_env_var_does_not_bypass(self):
+        with mock.patch.dict(os.environ, {"TUF_ON_CI_NO_VERIFY_KID": ""}):
+            self.assertFalse(_keyid_matches_content(self.non_matching_key))
 
 
 class TestCIRepository(unittest.TestCase):

--- a/repo/tuf_on_ci/_repository.py
+++ b/repo/tuf_on_ci/_repository.py
@@ -52,6 +52,25 @@ def get_signer(key: Key) -> str:
     return key.unrecognized_fields[TAG_ONLINE_URI]
 
 
+def _keyid_matches_content(key: Key) -> bool:
+    """Return True if key.keyid equals sha256(canonical(key.to_dict())).
+
+    The check can be disabled by setting the TUF_ON_CI_NO_VERIFY_KID
+    environment variable (to any non-empty value), in which case this
+    function always returns True.
+    Previous releases didn't include the x-tuf-on-ci* fields when computing
+    the kid, by making this check optional there is an upgrade path for them
+    withouth a "key rotation" (re-adding the key but with a new key id).
+    """
+    if os.environ.get("TUF_ON_CI_NO_VERIFY_KID"):
+        return True
+    canonical_key = encode_canonical(key.to_dict())
+    assert canonical_key
+    hasher = digest("sha256")
+    hasher.update(canonical_key.encode())
+    return key.keyid == hasher.hexdigest()
+
+
 @unique
 class State(Enum):
     ADDED = (0,)
@@ -365,11 +384,7 @@ class CIRepository(Repository):
                     return False, "Online signing or expiry period failed sanity check"
 
             for key in md.signed.keys.values():
-                canonical_key = encode_canonical(key.to_dict())
-                assert canonical_key
-                hasher = digest("sha256")
-                hasher.update(canonical_key.encode())
-                if key.keyid != hasher.hexdigest():
+                if not _keyid_matches_content(key):
                     return False, f"Key {key.keyid} keyid does not match content hash"
 
         # TODO for root:


### PR DESCRIPTION
Disablement happens by setting the environment variable TUF_ON_CI_NO_VERIFY_KID to a non empty value.

See https://github.com/kommendorkapten/tuf-repo-test-3/pull/52 for a test event.

First we get a warning of key id mismatch, then the event action is updated to this branch, and no warnings are printed when retriggered.