### PR TITLE
Describe what actually changed in an online delegation

### DIFF
--- a/signer/src/tuf_on_ci_sign/_signer_repository.py
+++ b/signer/src/tuf_on_ci_sign/_signer_repository.py
@@ -676,7 +676,7 @@ class SignerRepository(Repository):
             if signed.version != 1:
                 output.append(
                     f"   (expiry period was {old_expiry} days, "
-                    f"signing period was {old_signing} days"
+                    f"signing period was {old_signing} days)"
                 )
 
         return output
@@ -745,13 +745,28 @@ class SignerRepository(Repository):
 
                 if role != old_role:
                     output.append(f" * Modified {title}")
-                    output.append(
-                        f"   * Signers: {role.threshold}/{len(signers)} of {signers}"
-                    )
-                    output.append(
-                        f"     (was: {old_role.threshold}/{len(old_signers)} "
-                        f"of {old_signers}"
-                    )
+                    # Only describe what actually changed. A delegation also
+                    # carries the expiry and signing periods, so a change to
+                    # those alone used to be reported as a signer change.
+                    if role.threshold != old_role.threshold or signers != old_signers:
+                        output.append(
+                            f"   * Signers: {role.threshold}/{len(signers)} "
+                            f"of {signers}"
+                        )
+                        output.append(
+                            f"     (was: {old_role.threshold}/{len(old_signers)} "
+                            f"of {old_signers})"
+                        )
+                    for field, label in (
+                        ("x-tuf-on-ci-expiry-period", "Expiry period"),
+                        ("x-tuf-on-ci-signing-period", "Signing period"),
+                    ):
+                        period = role.unrecognized_fields.get(field)
+                        old_period = old_role.unrecognized_fields.get(field)
+                        if period != old_period:
+                            output.append(
+                                f"   * {label}: {period} days (was: {old_period} days)"
+                            )
                 del old_delegations[name]
 
         for name in old_delegations:

--- a/signer/test/test_signer_repository.py
+++ b/signer/test/test_signer_repository.py
@@ -49,3 +49,76 @@ class TestUser(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestDelegationStatusLines(unittest.TestCase):
+    """Test the change description produced for online delegations"""
+
+    def _repo(self, mutate) -> SignerRepository:
+        """Build a signer repository from the test repo, with root.json mutated.
+
+        Only _dir and _prev_dir are needed to produce delegation status lines,
+        so the signing event state that __init__ would look for is not set up.
+        """
+        import json
+        import os
+        import shutil
+        from tempfile import mkdtemp
+
+        src = os.path.join(os.path.dirname(__file__), "..", "..", "repo", "test")
+        src = os.path.join(src, "test_repo1")
+
+        prev_dir = mkdtemp()
+        cur_dir = mkdtemp()
+        self.addCleanup(shutil.rmtree, prev_dir)
+        self.addCleanup(shutil.rmtree, cur_dir)
+        for d in (prev_dir, cur_dir):
+            path = os.path.join(d, "root.json")
+            shutil.copyfile(os.path.join(src, "root.json"), path)
+            with open(path) as f:
+                root = json.load(f)
+            # Delegation changes are only described from v2 onwards: at v1 there
+            # is no previous delegation set to compare against.
+            root["signed"]["version"] = 2
+            if d == cur_dir:
+                mutate(root["signed"])
+            with open(path, "w") as f:
+                json.dump(root, f)
+
+        repo = SignerRepository.__new__(SignerRepository)
+        repo._dir = cur_dir
+        repo._prev_dir = prev_dir
+        return repo
+
+    def test_expiry_period_change_is_described(self):
+        """A changed online expiry period is reported as such, not as signers."""
+
+        def mutate(signed):
+            signed["roles"]["timestamp"]["x-tuf-on-ci-expiry-period"] = 10
+
+        lines = self._repo(mutate)._delegation_status_lines("root")
+
+        self.assertIn(" * Modified online delegations timestamp & snapshot", lines)
+        self.assertIn("   * Expiry period: 10 days (was: 4 days)", lines)
+        # The signers did not change, so they should not be described as changed.
+        self.assertFalse([line for line in lines if "Signers:" in line])
+
+    def test_threshold_change_is_described(self):
+        """A changed threshold still reports signers, with a closed paren."""
+
+        def mutate(signed):
+            signed["roles"]["timestamp"]["threshold"] = 2
+
+        lines = self._repo(mutate)._delegation_status_lines("root")
+
+        signer_lines = [line for line in lines if "Signers:" in line or "was:" in line]
+        self.assertEqual(len(signer_lines), 2)
+        self.assertTrue(signer_lines[1].rstrip().endswith(")"), signer_lines[1])
+
+    def test_unchanged_delegation_is_not_reported(self):
+        def mutate(signed):
+            pass
+
+        lines = self._repo(mutate)._delegation_status_lines("root")
+
+        self.assertFalse([line for line in lines if "Modified" in line])


### PR DESCRIPTION
Fixes #199.

Two separate things are behind that output.

The `(was:` line is never closed. `_role_status_lines` has the same omission on its `(expiry period was ...` line, so that one is fixed here too.

The more useful half is why signers are being described at all. A delegation `Role` carries `x-tuf-on-ci-expiry-period` and `x-tuf-on-ci-signing-period` in its unrecognized fields next to the keyids and threshold, so changing a period alone makes `role != old_role` true. The block underneath only ever printed signers, which is why a period change came out as a signer change that had not happened.

So this prints the signer line only when the threshold or the signers actually differ, and prints a changed period on its own line. For the case in the issue:

```
 * Modified online delegations timestamp & snapshot
   * Expiry period: 10 days (was: 4 days)
```

I did not chase the `1/0 of []` in your paste. `_get_keys(known_good=True)` deliberately skips known-good keys that carry neither `x-tuf-on-ci-keyowner` nor `x-tuf-on-ci-online-uri`, for the repo-import case, and I could not tell from here whether your repository hits that path or something else. With this change the line is not printed for a period-only change anyway, but if the empty list shows up on a genuine signer change it is worth a separate look.

## Testing

Three cases in `signer/test/test_signer_repository.py`, driving `_delegation_status_lines` against a copy of `repo/test/test_repo1`: a period change, a threshold change, and no change at all. The threshold case asserts the `(was:` line ends in `)`, so it covers the paren rather than leaving it to review.

Against `main`, the first two fail:

```
FAILED test/test_signer_repository.py::TestDelegationStatusLines::test_expiry_period_change_is_described
FAILED test/test_signer_repository.py::TestDelegationStatusLines::test_threshold_change_is_described
E       AssertionError: False is not true :      (was: 1/1 of ['envvar']
```

One thing worth your eye: the fixture builds the repository with `SignerRepository.__new__` and sets `_dir`/`_prev_dir`, because producing delegation status lines needs nothing else and setting up a full signing event for this seemed disproportionate. Happy to build a real one instead if you would rather the test go through `__init__`.

The fixture also bumps root to v2 in both copies, since `_delegation_status_lines` only populates `old_delegations` when `root.version > 1` and everything reads as "New" at v1.

`ruff check signer`, `ruff format --check signer` and `pytest signer/test` are clean. `mypy signer` reports two pre-existing errors in `_user.py` and `_common.py`, which I did not touch and which also appear without this change.
